### PR TITLE
Use own progress bar instead of PyDelphin's

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pydelphin==1.3.0
+pydelphin==1.4.0


### PR DESCRIPTION
Using the latest version (1.4.0) of PyDelphin, we can disable its progress bar and use our own. With this, the progress looks like this:

![Screenshot from 2020-07-20 18-56-36](https://user-images.githubusercontent.com/1428419/87930540-db49dc00-caba-11ea-8d25-c93577c8b5c5.png)

Note how the test name is abbreviated (`...`) when it gets too long. You shouldn't have any wrapping problems unless you resize while it's working or have a window with < 30 (or so) columns.