### PR TITLE
Use multiprocessing to speed up regression tests

### DIFF
--- a/rtest.py
+++ b/rtest.py
@@ -201,6 +201,10 @@ def _run_test(
             traceback.print_exc(file=logf)
             result = ERROR
 
+        # delete the dat file; it's a big file that's easy to recreate
+        if dat.exists():
+            dat.unlink()
+
         _lognow('\nResult: ' + result, logf)
         return name, result, log
 

--- a/rtest.py
+++ b/rtest.py
@@ -52,7 +52,7 @@ LOGS_DIR.mkdir(exist_ok=True)
 
 # MULTIPROCESSING PARAMETERS ##################################################
 
-PROCESSES = 4  # max parallel processes for testing
+PROCESSES = None  # max parallel processes for testing; 'None'->os.cpu_count()
 BATCH_SIZE = 1  # number of jobs per process to complete before reporting
 
 

--- a/rtest.py
+++ b/rtest.py
@@ -592,7 +592,7 @@ def _unique_log_path(name):
 def _progress_bar(numerator: int, denominator: int) -> str:
     max_width = min(PROGRESS_BAR_WIDTH, linewidth())
     count_width = len(str(denominator))
-    bar_width = max(10, max_width - (count_width * 2) - len('[] (/)'))
+    bar_width = max(10, max_width - (count_width * 2) - len('[] (/) '))
     fillcols = int((numerator / denominator) * bar_width)
     fill = '#' * fillcols
     return f'[{fill:<{bar_width}}] ({numerator:>{count_width}}/{denominator})'


### PR DESCRIPTION
Less frequent and detailed reporting of test progress, but ~2x faster.

The time to run all tests for me went from ~4.5 min to ~2.3 min. Can someone else please test this out and report before/after times?

Because the processes are done in parallel, I cannot easily print the detailed `[customizing]`, `[compiling]`, etc. statuses as before, nor what test is currently running, so instead I just print the final result and make the progress bar fill the entire width. I added a counter to the progress bar, as well. It now looks like this:

![Screenshot from 2020-08-02 12-35-33](https://user-images.githubusercontent.com/1428419/89115599-bee76f80-d4bc-11ea-92bf-4f8cb0476bf7.png)

This uses 4 processes (configured with the `PROCESSES` variable), which works for me because I have 4 cores on my processor. I could just not specify the number of processes, which defaults to `os.cpu_count()`, but I don't want to use > 4 (on more powerful systems) because these all share the system memory and I don't want to risk that parses fail because of memory errors. I don't think there's much difference in speed if I request more processes than available processors/cores.

There's also a `BATCH_SIZE` variable which controls how many jobs are processed on each process before reporting, but my experiments did not show any benefit to increasing this. The bottleneck is probably all the disk writing, and there's not much batching can do about that.