### PR TITLE
rtest.py usability improvements

### DIFF
--- a/rtest.py
+++ b/rtest.py
@@ -73,6 +73,7 @@ def linewidth(): return min(MAX_LINE_WIDTH, shutil.get_terminal_size()[0])
 
 # ANSI colors; see: https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 def red(s): return color('\x1b[31m', s)
+def boldred(s): return color('\x1b[31m\x1b[1m', s)
 def green(s): return color('\x1b[32m', s)
 def yellow(s): return color('\x1b[33m', s)
 def color(clr, s): return '{}{}\x1b[0m'.format(clr, s)
@@ -83,9 +84,9 @@ def yes_or_no(obj): return red('no') if obj is None else green('yes')
 REPORT_COLOR = {
     DONE: green,
     PASS: green,
-    FAIL: yellow,
+    FAIL: red,
     SKIP: yellow,
-    ERROR: red
+    ERROR: boldred
 }
 
 

--- a/rtest.py
+++ b/rtest.py
@@ -113,18 +113,9 @@ def main(args):
         args.index = pathlib.Path(args.index).expanduser()
     else:
         args.index = INDEX
-    if args.list:
-        list_tests(args)
-    elif args.update:
-        update_test(args)
-    elif args.add:
-        add_test(args)
-    elif args.remove:
-        remove_test(args)
-    elif args.clean:
-        clean_up(args)
-    else:
-        run_tests(args)
+    if args.add:
+        args.function = add_test
+    return args.function(args)
 
 
 def run_tests(args):
@@ -730,7 +721,9 @@ if __name__ == '__main__':
                         metavar='PATH',
                         help='path to a test index')
     parser.add_argument('-l', '--list',
-                        action='store_true',
+                        const=list_tests,
+                        dest='function',
+                        action='store_const',
                         help='list available tests (-v, -vv for more info)')
     parser.add_argument('--skipped',
                         action='store_true',
@@ -748,23 +741,31 @@ if __name__ == '__main__':
                         action='store_true',
                         help='compare test profile to gold')
     parser.add_argument('-u', '--update',
-                        action='store_true',
+                        const=update_test,
+                        dest='function',
+                        action='store_const',
                         help='copy the current profile to gold')
     parser.add_argument('-a', '--add',
                         nargs=2,
                         metavar=('CHOICES', 'TXTSUITE'),
                         help='add a new test to the system')
     parser.add_argument('-r', '--remove',
-                        action='store_true',
+                        const=remove_test,
+                        dest='function',
+                        action='store_const',
                         help='remove a test from the system')
     parser.add_argument('--clean',
-                        action='store_true',
+                        const=clean_up,
+                        dest='function',
+                        action='store_const',
                         help='delete temporary grammars, logs, and profiles')
     parser.add_argument('--debug',
                         action='store_true',
                         help='disable multiprocessing to help debuggers')
     parser.add_argument('test',
                         nargs='*')
+
+    parser.set_defaults(function=run_tests)
 
     args = parser.parse_args()
 

--- a/rtest.py
+++ b/rtest.py
@@ -773,7 +773,8 @@ if __name__ == '__main__':
     parser.add_argument('test',
                         nargs='*')
 
-    parser.set_defaults(function=run_tests)
+    parser.set_defaults(force=False,
+                        function=run_tests)
 
     args = parser.parse_args()
 

--- a/rtest.py
+++ b/rtest.py
@@ -568,7 +568,11 @@ def _mkskel(name, txt, logf):
         raise RegressionTestError(
             f'Did you forget to add the new txt-suite to {TXT_SUITE_DIR!s}?')
     try:
-        mkprof(dest, source=txt, schema=RELATIONS_FILE, quiet=True)
+        mkprof(dest,
+               source=txt,
+               schema=RELATIONS_FILE,
+               skeleton=True,
+               quiet=True)
     except CommandError as exc:
         raise RegressionTestError('Failed to prepare skeleton.') from exc
 

--- a/rtest.py
+++ b/rtest.py
@@ -396,6 +396,7 @@ def clean_up(args):
     2) current profiles
     3) logs
     '''
+    count = 0
     for name, _, _, _, _, prof, _ in _discover(args):
         deleted = False
         grm = GRAMMARS_DIR / name
@@ -412,7 +413,10 @@ def clean_up(args):
             log.unlink()
             deleted = True
         if deleted:
-            print(f'cleaned files for {name}')
+            count += 1
+            if args.verbosity >= 2:
+                print(f'cleaned files for {name}')
+    print(f'Finished cleaning files for {count} tests.')
 
 
 # HELPER FUNCTIONS ############################################################

--- a/rtest.py
+++ b/rtest.py
@@ -100,11 +100,9 @@ class RegressionTestError(Exception):
 def main(args):
     # if no steps are specified, do all of them (but this may be
     # avoided by using --list or --update)
-    if not any([args.customize, args.mkskel, args.mkprof,
-                args.process, args.compare]):
+    if not any([args.customize, args.mkskel, args.process, args.compare]):
         args.customize = True
         args.mkskel = None  # `None` here means "only if needed"
-        args.mkprof = True
         args.process = True
         args.compare = True
 
@@ -145,7 +143,6 @@ def run_tests(args):
         _run_test,
         customize=args.customize,
         mkskel=args.mkskel,
-        mkprof=args.mkprof,
         process=args.process,
         compare=args.compare,
     )
@@ -175,7 +172,6 @@ def _run_test(
         args,
         customize=False,
         mkskel=False,
-        mkprof=False,
         process=False,
         compare=False,
 ) -> Tuple[str, str, pathlib.Path]:
@@ -198,9 +194,8 @@ def _run_test(
                 # mkskel if requested or if necessary
                 if mkskel or (mkskel is None and skel is None):
                     skel = _mkskel(name, txt, logf)
-                if mkprof:
-                    prof = _mkprof(name, skel, logf)
                 if process:
+                    prof = _mkprof(name, skel, logf)
                     _process(name, dat, prof, logf)
                 if compare:
                     passed = _compare(name, prof, gold, logf)
@@ -313,7 +308,6 @@ def add_test(args):
     # current profile.
     args.customize = True
     args.mkskel = True
-    args.mkprof = True
     args.process = True
     args.compare = False
     run_tests(args)
@@ -328,7 +322,6 @@ def add_test(args):
     # Test the new test:
     args.customize = False
     args.mkskel = False
-    args.mkprof = False
     args.process = False
     args.compare = True
     run_tests(args)
@@ -665,12 +658,11 @@ if __name__ == '__main__':
         Regression testing involves a pipeline of independent steps.
         If no steps are specified, all test steps below are executed:
 
-        Step         Requires       Result
-        ===========  =============  ============================
-        --customize  choices        dat (compiled grammar image)
-        --mkprof     skeleton       profile (unprocessed)
-        --process    dat, profile   profile (processed)
-        --compare    profile, gold  regression test results
+        Step         Requires           Result
+        ===========  =============      ============================
+        --customize  choices            customized grammar
+        --process    grammar, skeleton  processed profile
+        --compare    profile, gold      regression test results
 
         Also, the following are for constructing and updating tests:
 
@@ -713,9 +705,6 @@ if __name__ == '__main__':
     parser.add_argument('-s', '--mkskel',
                         action='store_true',
                         help='make test skeletons from txt-suites')
-    parser.add_argument('-m', '--mkprof',
-                        action='store_true',
-                        help='make test profiles from skeletons')
     parser.add_argument('-p', '--process',
                         action='store_true',
                         help='process test profiles with compiled grammars')

--- a/rtest.py
+++ b/rtest.py
@@ -278,7 +278,7 @@ def add_test(args):
         name = args.test[0]
         idx, chc, txt = None, None, None
     elif len(tests) == 1:
-        name, idx, chc, _, txt, _, _, _ = tests[0]
+        name, idx, chc, txt, _, _, _ = tests[0]
     else:
         raise RegressionTestError('only 1 test may be added at a time')
 

--- a/rtest.py
+++ b/rtest.py
@@ -157,15 +157,16 @@ def run_tests(args):
                 print('  see: {}'.format(str(logpath)))
             print('\r' + _progress_bar(i, total), end='')
             totals[result] += 1
+    print()  # end progress bar line
 
     if args.compare:
-        print('\n******** SUMMARY *************')
+        print('\n************* SUMMARY *************')
         width = len(str(total))  # to align the numbers on /
-        print('Passed {0:{2}}/{1} tests;'.format(totals[PASS], total, width))
-        print('Failed {0:{2}}/{1} tests;'.format(totals[FAIL], total, width))
-        print('Errors {0:{2}}/{1} tests;'.format(totals[ERROR], total, width))
+        print('Passed  {0:{2}}/{1} tests'.format(totals[PASS], total, width))
+        print('Failed  {0:{2}}/{1} tests'.format(totals[FAIL], total, width))
+        print('Errors  {0:{2}}/{1} tests'.format(totals[ERROR], total, width))
         if totals[SKIP]:
-            print('Skipped {0:{2}}/{1} tests.'
+            print('Skipped {0:{2}}/{1} tests'
                   ' (run rtest.py --list --skipped --verbose for more info)'
                   .format(totals[SKIP], total, width))
 

--- a/rtest.py
+++ b/rtest.py
@@ -234,7 +234,7 @@ def list_tests(args, verbose=False):
             if idx:
                 desc = idx.get('description')
                 if idx.get('skip'):
-                    skip = green('yes')
+                    skip = f'{yellow("yes")} (disabled in index)'
                 elif _skipped(idx, chc, skel, gold):
                     skip = f'{red("yes")} (missing components)'
                 else:

--- a/rtest.py
+++ b/rtest.py
@@ -131,6 +131,7 @@ def run_tests(args):
         mkskel=args.mkskel,
         process=args.process,
         compare=args.compare,
+        force=args.force or args.skipped,
     )
 
     if args.debug:
@@ -159,6 +160,7 @@ def _run_test(
         mkskel=False,
         process=False,
         compare=False,
+        force=False,
 ) -> Tuple[str, str, pathlib.Path]:
     name, idx, chc, txt, skel, prof, gold = args
     log = _unique_log_path(name)
@@ -169,7 +171,7 @@ def _run_test(
                 .format(name, datetime.datetime.now().isoformat()),
                 logf)
 
-        if _skipped(idx, chc, skel, gold):
+        if not force and _skipped(idx, chc, skel, gold):
             result = SKIP
         else:
             try:
@@ -309,6 +311,7 @@ def add_test(args):
     args.mkskel = True
     args.process = True
     args.compare = False
+    args.force = True  # it would skip otherwise because GOLD is not there
     run_tests(args)
     try:
         # Need to copy current profile to gold, as at this stage the
@@ -323,6 +326,7 @@ def add_test(args):
     args.mkskel = False
     args.process = False
     args.compare = True
+    args.force = False  # should work now
     run_tests(args)
 
     # list the current state

--- a/rtest.py
+++ b/rtest.py
@@ -6,6 +6,7 @@ Grammar Matrix Regression Testing
 """
 
 from typing import Tuple
+import sys
 import traceback
 import shutil
 import argparse
@@ -152,6 +153,9 @@ def run_tests(args):
             print('Skipped {0:{2}}/{1} tests'
                   ' (run rtest.py --list --skipped --verbose for more info)'
                   .format(totals[SKIP], total, width))
+
+    success = totals[ERROR] + totals[FAIL] == 0
+    return 0 if success else 1
 
 
 def _run_test(
@@ -773,4 +777,5 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    main(args)
+    exit_status = main(args)
+    sys.exit(exit_status)

--- a/tests/regression/regression-test-index
+++ b/tests/regression/regression-test-index
@@ -96,6 +96,7 @@ German=German (sfd dissertation)
 Hindi=Hindi (sfd dissertation)
 Tagalog=Tagalog (sfd dissertation)
 case-mixed2=mixed adpositional and morphological marking (2)
+!Sahaptin=Sahaptin (sfd dissertation)
 Sahaptin-short=Sahaptin, shorter version (sfd dissertation)
 qpart-yes-no=Questions marked via sentence-initial question particle.
 infl-q-main-verb=Question marking as inflection on the main verb, no other affixes


### PR DESCRIPTION
**Edit:** I updated the title and body to broaden the scope of this PR a bit.

### Skipped Tests

There is now a notion of "skipped" tests, which come in two flavors: "disabled" tests are those annotated in `regression-test-index` with `!`, meaning they are to be skipped; and "incomplete" tests are those that are missing some required files (choices, skeleton, gold profile) or are not indexed.

- [X] add SKIP result category
- [X] add `!` prefix to regression-test-index format for disabled tests
- [X] replace `--all-tests` with `--skipped` which limits test discovery to skipped tests
- [X] print skipped status and reason with `rtest.py --list --verbose`

Some more testing is needed. In particular:

- [x] check behavior with a disabled test
- [x] ensure adding tests still works
- [x] ensure removing tests still works

Resolves #497 

### Simplified Testing Pipeline

Now that `grm.dat` files are deleted, the current pipeline makes less sense. So now:

- [x] remove `--mkprof` option; instead, create profile from skeleton during `--process`
- [x] compile and delete `grm.dat` during `--process`
- [x] run customization when `--process` is used, even if `--customize` is not

Additionally:

- [x] prevent `--mkskel` from creating non-skeleton files (edge, result, etc.)

### Other

A few other related changes to help with scripting and debugging:

- [x] `rtest.py` returns a nonzero exit code if tests fail or have errors
- [x] `--debug` turns off features that may interfere with a debugger, namely multiprocessing
- [x] `--clean` deletes customized grammars, logs, and current profiles
