### PR TITLE
Wh cleanup

### DIFF
--- a/gmcs/linglib/clausalcomps.py
+++ b/gmcs/linglib/clausalcomps.py
@@ -633,7 +633,7 @@ def customize_clausal_verb(clausalverb,mylang,ch,cs,extra):
 
     if not is_nominalized_complement(cs):
         if cs['ques'] == 'prop':
-            mylang.add(clausalverb + ' := [ SYNSEM [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.WH.LOGICAL-OR.BOOL -, '
+            mylang.add(clausalverb + ' := [ SYNSEM [ LOCAL.CAT.VAL.COMPS < [ LOCAL [ CAT.WH.BOOL -, '
                                      '                                               CONT.HOOK.INDEX.SF prop ] ] >,'
                                      'NON-LOCAL.QUE 0-alist ] ].'
                        , merge=True)
@@ -641,7 +641,7 @@ def customize_clausal_verb(clausalverb,mylang,ch,cs,extra):
             mylang.add(clausalverb + ' := [ SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SF ques ] > ].'
                        , merge=True)
             if ch.get(MTRX_FRONT) in [SINGLE, MULTI] and not ch.get('embed-insitu') == 'on':
-                mylang.add(clausalverb + ' := [ SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.WH.LOGICAL-OR.BOOL + ] > ].'
+                mylang.add(clausalverb + ' := [ SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.WH.BOOL + ] > ].'
                            , merge=True)
 
     if ch.get('wh-inv-embed') == 'on':

--- a/gmcs/linglib/lexbase.py
+++ b/gmcs/linglib/lexbase.py
@@ -124,8 +124,8 @@ WH_DET = '''wh-determiner-lex := basic-wh-word-lex & basic-determiner-lex & non-
 
 ADP_LEX = '''norm-adposition-lex := norm-sem-lex-item & no-hcons-lex-item & basic-intersective-mod-lex & basic-one-arg &
   [ SYNSEM [ LOCAL [ CAT [ HEAD adp & [ MOD < [ LOCAL.CAT [ VAL.SPR cons, 
-                                                            WH.LOGICAL-OR.BOOL - ] ] > ],
-                           WH or-and-minus,
+                                                            WH.BOOL - ] ] > ],
+                           WH.BOOL -,
                            VAL [ SPR < >,
                                  SPEC < >,
                                  SUBJ < >,

--- a/gmcs/linglib/wh_ques.py
+++ b/gmcs/linglib/wh_ques.py
@@ -23,7 +23,7 @@ WH_Q_PHR = ''' wh-ques-phrase := basic-head-filler-phrase & interrogative-clause
      HEAD-DTR.SYNSEM [ LOCAL.CAT [ VAL #val & [ SUBJ < >,
 					                            COMPS < > ] ] ],
      NON-HEAD-DTR.SYNSEM [ NON-LOCAL.QUE.LIST < ref-ind >,
-                           LOCAL.CONT.HOOK.ICONS-KEY focus ] ] .'''
+                           LOCAL.CONT.HOOK.ICONS-KEY focus ] ].'''
 
 
 MAIN_WHQ = '''main-wh-ques-phrase := wh-ques-phrase &

--- a/gmcs/linglib/wh_ques.py
+++ b/gmcs/linglib/wh_ques.py
@@ -15,13 +15,15 @@ WH_Q_PHR_NO_OR_SG_OBLIG_MULTI = '''wh-ques-phrase :=
      HEAD-DTR.SYNSEM.NON-LOCAL.QUE #que ].'''
 
 WH_Q_PHR = ''' wh-ques-phrase := basic-head-filler-phrase & interrogative-clause & head-final &
-[ SYNSEM [ LOCAL.CAT [ WH.LOGICAL-OR.BOOL +, MC bool,
-			VAL #val,
-			HEAD verb ], NON-LOCAL.QUE 0-alist ],
+[ SYNSEM [ LOCAL [ CAT [ WH.BOOL +, 
+                       MC bool,
+			           VAL #val,
+			           HEAD verb ] ], 
+			NON-LOCAL.QUE.LIST < > ],
      HEAD-DTR.SYNSEM [ LOCAL.CAT [ VAL #val & [ SUBJ < >,
-					      COMPS < > ] ] ],
+					                            COMPS < > ] ] ],
      NON-HEAD-DTR.SYNSEM [ NON-LOCAL.QUE.LIST < ref-ind >,
-                           LOCAL.CONT.HOOK.ICONS-KEY focus ] ].'''
+                           LOCAL.CONT.HOOK.ICONS-KEY focus ] ] .'''
 
 
 MAIN_WHQ = '''main-wh-ques-phrase := wh-ques-phrase &
@@ -98,9 +100,9 @@ from gmcs.constants import MTRX_FR_OPT, MTRX_FRONT, NO_MULTI, \
 def customize_wh_feature(mylang,ch):
     mylang.add('cat :+ [ WH and-or ].')
     if ch.get(MTRX_FRONT):
-        mylang.add('wh-ques-phrase := [ SYNSEM.LOCAL.CAT.WH.LOGICAL-OR.BOOL + ].')
+        mylang.add('wh-ques-phrase := [ SYNSEM.LOCAL.CAT.WH.BOOL + ].')
         if len(ch.get('adv', [])) > 0 or len(ch.get('normadp', [])) > 0:
-            mylang.add('norm-adposition-lex := [ SYNSEM.LOCAL.CAT.WH or-and-plus ].')
+            mylang.add('norm-adposition-lex := [ SYNSEM.LOCAL.CAT.WH.BOOL + ].')
 
 
 
@@ -134,7 +136,7 @@ def customize_wh_ques(mylang,ch,rules,roots):
         if ch.get(MTRX_FRONT) in [SINGLE]:
             mylang.add('''wh-ques-phrase := [ HEAD-DTR.SYNSEM.NON-LOCAL.QUE 0-alist ].''')
         if len(ch.get('adv', [])) > 0 or len(ch.get('normadp', [])) > 0:
-            mylang.add('''wh-adverb-lex := [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT.WH.LOGICAL-OR.BOOL - ] > ].''')
+            mylang.add('''wh-adverb-lex := [ SYNSEM.LOCAL.CAT.HEAD.MOD < [ LOCAL.CAT.WH.BOOL - ] > ].''')
 
     mylang.add_literal(';;; Wh-question-related phrasal types',section='phrases')
 
@@ -247,11 +249,11 @@ def customize_wh_ques(mylang,ch,rules,roots):
         rules.add('in-situ-ques := insitu-int-cl.')
         if not ch.get(MTRX_FRONT) == IN_SITU:
             if ch.get(EMBED_INSITU) == ON:
-                mylang.add('insitu-int-cl := [ SYNSEM.LOCAL.CAT.WH.LOGICAL-OR.BOOL + ].')
+                mylang.add('insitu-int-cl := [ SYNSEM.LOCAL.CAT.WH.BOOL + ].')
             else:
-                mylang.add('insitu-int-cl := [ SYNSEM.LOCAL.CAT.WH.LOGICAL-OR.BOOL - ].')
+                mylang.add('insitu-int-cl := [ SYNSEM.LOCAL.CAT.WH.BOOL - ].')
         else:
-            mylang.add('''insitu-int-cl := [ SYNSEM.LOCAL.CAT.WH.LOGICAL-OR.BOOL + ].''')
+            mylang.add('''insitu-int-cl := [ SYNSEM.LOCAL.CAT.WH.BOOL + ].''')
         if ch.get(MTRX_FRONT) in [SINGLE,MULTI]:
             mylang.add('insitu-int-cl := [ SYNSEM.L-QUE - ].')
         if (ch.get(MTRX_FRONT) == SINGLE
@@ -298,7 +300,7 @@ def customize_wh_ques(mylang,ch,rules,roots):
 
     if ch.get('q-part') == ON:
         if ch.get(MTRX_FRONT) == IN_SITU:
-            mylang.add('insitu-int-cl := [ SYNSEM.LOCAL.CAT.WH.LOGICAL-OR.BOOL + ].')
+            mylang.add('insitu-int-cl := [ SYNSEM.LOCAL.CAT.WH.BOOL + ].')
             # Perhaps this special case below can be dealt with differently?
             # Like with the WH feature?
             if len(ch.get('q-particle')) == 1:

--- a/gmcs/linglib/yes_no_questions.py
+++ b/gmcs/linglib/yes_no_questions.py
@@ -237,3 +237,4 @@ def customize_yesno_questions(mylang, ch, rules, lrules, hierarchies,roots):
                 if ch.get('q-part-order') != 'second':
                     mylang.add(typename + ':= [ SYNSEM.LOCAL.CAT.VAL.COMPS.FIRST '
                                           '[ LOCAL.CAT.WH.BOOL +  ] ].')
+                    

--- a/gmcs/linglib/yes_no_questions.py
+++ b/gmcs/linglib/yes_no_questions.py
@@ -228,12 +228,12 @@ def customize_yesno_questions(mylang, ch, rules, lrules, hierarchies,roots):
             if qpart['wh'] == 'imp':
                 if ch.get('q-part-order') != 'second':
                     mylang.add(typename + ':= [ SYNSEM.LOCAL.CAT.VAL.COMPS.FIRST '
-                                          '[ LOCAL.CAT.WH or-and-minus ] ].')
+                                          '[ LOCAL.CAT.WH.BOOL - ] ].')
                 else:
                     mylang.add(typename + ':= [ SYNSEM.LOCAL.CAT.HEAD.MOD.FIRST '
-                                          '[ LOCAL.CAT.WH or-and-minus ] ].')
+                                          '[ LOCAL.CAT.WH.BOOL - ] ].')
 
             elif qpart['wh'] == 'oblig':
                 if ch.get('q-part-order') != 'second':
                     mylang.add(typename + ':= [ SYNSEM.LOCAL.CAT.VAL.COMPS.FIRST '
-                                          '[ LOCAL.CAT.WH or-and-plus  ] ].')
+                                          '[ LOCAL.CAT.WH.BOOL +  ] ].')

--- a/matrix-core/matrix.tdl
+++ b/matrix-core/matrix.tdl
@@ -274,15 +274,6 @@ cat-min := avm.
 ; also that it is WH.BOOL +. A constituent question will be WH.BOOL + if the head-complement
 ; rule's mother's WH is the OR of its daughters.
 
-or-and := avm &
-[ LOGICAL-OR logical-or ].
-
-or-and-minus := or-and &
-[ LOGICAL-OR.BOOL - ].
-
-or-and-plus := or-and &
-[ LOGICAL-OR.BOOL + ].
-
 cat := cat-min &
   [ HEAD head-min,
     VAL valence-min,
@@ -290,7 +281,7 @@ cat := cat-min &
     MKG mkg,
     HC-LIGHT luk,
     POSTHEAD bool,
-    WH or-and ].
+    WH logical-or ].
 
 cat-sat := cat &
  [ VAL [ SPR olist,
@@ -1967,18 +1958,18 @@ nc-head-filler-phrase := nc-filler-phrase & head-compositional.
 basic-head-subj-phrase := head-valence-phrase & head-compositional &
 			  basic-binary-headed-phrase &
   [ SYNSEM phr-synsem &
-           [ LOCAL.CAT [ WH [ LOGICAL-OR.OR < #or1, #or2 > ],
+           [ LOCAL.CAT [ WH [ OR < #or1, #or2 > ],
                          HC-LIGHT -,
                          VAL [ SPEC #spec,
                                SUBJ < >,
                                COMPS #comps,
                                SPR #spr ] ] ],
-    HEAD-DTR.SYNSEM.LOCAL.CAT [ WH [ LOGICAL-OR #or1 ],
+    HEAD-DTR.SYNSEM.LOCAL.CAT [ WH  #or1,
                                 VAL [ SPEC #spec, SUBJ < #synsem >,
                                     COMPS #comps,
                                     SPR #spr ] ],
     NON-HEAD-DTR.SYNSEM #synsem & canonical-synsem &
-           [ LOCAL [ CAT [ WH [ LOGICAL-OR #or2 ],
+           [ LOCAL [ CAT [ WH #or2,
                            VAL [ SUBJ olist,
                                  COMPS olist,
                                  SPR olist ] ] ],
@@ -2027,7 +2018,7 @@ basic-head-subj-nmc-phrase := head-valence-phrase & basic-binary-headed-phrase &
 basic-head-spec-phrase-super := head-valence-phrase & phrasal &
               binary-headed-phrase &
   [ INFLECTED infl-satisfied,
-    SYNSEM [ LOCAL.CAT [ WH [ LOGICAL-OR.OR < #or1, #or2 > ],
+    SYNSEM [ LOCAL.CAT [ WH [ OR < #or1, #or2 > ],
                          VAL [ SUBJ #subj,
                                COMPS #spcomps,
                                SPR #spr,
@@ -2036,7 +2027,7 @@ basic-head-spec-phrase-super := head-valence-phrase & phrasal &
                          HC-LIGHT - ],
               MODIFIED #modif ],
     HEAD-DTR [ INFLECTED infl-satisfied,
-               SYNSEM [ LOCAL [ CAT [ WH [ LOGICAL-OR #or1 ],
+               SYNSEM [ LOCAL [ CAT [ WH #or1,
                                       HEAD #head,
                                       VAL [ SUBJ #subj,
                                             COMPS olist & #comps,
@@ -2047,7 +2038,7 @@ basic-head-spec-phrase-super := head-valence-phrase & phrasal &
                                 CONT.HOOK #hdhook ],
                         MODIFIED #hmodif ] ],
     NON-HEAD-DTR.SYNSEM #synsem &
-     [ LOCAL [ CAT [ WH [ LOGICAL-OR #or2 ], VAL [ SPEC < [ LOCAL [ CAT [ HEAD #head,
+     [ LOCAL [ CAT [ WH #or2, VAL [ SPEC < [ LOCAL [ CAT [ HEAD #head,
                                                   VAL.COMPS #comps ],
                                             CONT.HOOK #hdhook ],
                                     MODIFIED #hmodif ] >,
@@ -2075,20 +2066,20 @@ basic-head-spec-phrase := basic-head-spec-phrase-super &
 basic-head-comp-phrase := head-valence-phrase & head-compositional &
               binary-headed-phrase &
   [ SYNSEM phr-synsem-min &
-           [ LOCAL.CAT [ WH [ LOGICAL-OR.OR < #or1, #or2 > ],
+           [ LOCAL.CAT [ WH [ OR < #or1, #or2 > ],
                          VAL [ SUBJ #subj,
                                SPEC #spec,
                                SPR #spr ],
                          POSTHEAD #ph,
                          HC-LIGHT #light ],
              LIGHT #light ],
-    HEAD-DTR.SYNSEM [ LOCAL.CAT [ WH [ LOGICAL-OR #or1 ],
+    HEAD-DTR.SYNSEM [ LOCAL.CAT [ WH #or1,
                                   VAL [ SUBJ #subj,
                                         SPEC #spec,
                                         SPR #spr ],
                                   HC-LIGHT #light,
                                   POSTHEAD #ph ]],
-    NON-HEAD-DTR.SYNSEM canonical-synsem & [ LOCAL.CAT.WH [ LOGICAL-OR #or2 ] ],
+    NON-HEAD-DTR.SYNSEM canonical-synsem & [ LOCAL.CAT.WH #or2 ],
     C-CONT [ RELS.LIST < >, HCONS.LIST < >, ICONS.LIST < > ] ].
 
 
@@ -2519,11 +2510,11 @@ extracted-adj-first-phrase := extracted-adj-phrase &
 ; OZ 2020-01-25 Adding QUE append to support multiple questions.
 
 basic-head-mod-phrase-simple := head-mod-phrase & binary-headed-phrase &
-  [ SYNSEM [ LOCAL.CAT [ MKG #mkg, WH [ LOGICAL-OR.OR < #or1, #or2 > ] ],
+  [ SYNSEM [ LOCAL.CAT [ MKG #mkg, WH [ OR < #or1, #or2 > ] ],
              NON-LOCAL [ SLASH.APPEND < #s1, #s2 >,
                          REL 0-alist, QUE.APPEND < #q1, #q2 > ] ],
     HEAD-DTR.SYNSEM
-           [ LOCAL [ CAT [ WH [ LOGICAL-OR #or1 ],
+           [ LOCAL [ CAT [ WH #or1,
                            HEAD #head,
                            VAL #val,
                            POSTHEAD #ph,
@@ -2537,7 +2528,7 @@ basic-head-mod-phrase-simple := head-mod-phrase & binary-headed-phrase &
              LIGHT #light,
              MODIFIED #modif ],
     NON-HEAD-DTR.SYNSEM
-           [ LOCAL [ CAT [ WH [ LOGICAL-OR #or2 ], HEAD [ MOD < [ LOCAL local &
+           [ LOCAL [ CAT [ WH #or2, HEAD [ MOD < [ LOCAL local &
                                               [ CAT [ HEAD #head,
                                                       VAL #val,
                                                       POSTHEAD #ph,
@@ -3622,10 +3613,10 @@ basic-subord-conjunction-lex := basic-one-arg &
 
 
 basic-wh-word-lex := word &
-[ SYNSEM [ L-QUE +, LOCAL.CAT.WH or-and-plus ] ].
+[ SYNSEM [ L-QUE +, LOCAL.CAT.WH.BOOL + ] ].
 
 basic-non-wh-word-lex := word &
-[ SYNSEM [ L-QUE -, LOCAL.CAT.WH or-and-minus ] ].
+[ SYNSEM [ L-QUE -, LOCAL.CAT.WH.BOOL - ] ].
 
 ; Coming soon:
 ; Lexical type for negative particles like English "not"
@@ -3687,15 +3678,15 @@ nosem-conj-lex := basic-conj-lex &
 ; Coordination phrases and rules
 coord-phrase := binary-phrase &
   [ SYNSEM [ LOCAL [ COORD-STRAT #cstrat,
-                   CAT [ WH.LOGICAL-OR.OR #wh,
+                   CAT [ WH.OR #wh,
                          HEAD.MOD #mod,
                          VAL #val ] ],
 	     NON-LOCAL [ SLASH #slash, REL #rel, QUE #que2, YNQ.APPEND < #ynq1, #ynq2 > ] ],
-    LCOORD-DTR #ldtr & sign & [ SYNSEM [ LOCAL [ CAT [ WH.LOGICAL-OR.OR #wh, HEAD.MOD #mod,
+    LCOORD-DTR #ldtr & sign & [ SYNSEM [ LOCAL [ CAT [ WH.OR #wh, HEAD.MOD #mod,
                                                      VAL #val ] ],
 				         NON-LOCAL [ SLASH #slash, REL #rel, QUE append-list, YNQ #ynq1 ] ] ],
     RCOORD-DTR #rdtr & sign & [ SYNSEM [ LOCAL [ COORD-STRAT #cstrat,
-                                               CAT [ WH.LOGICAL-OR.OR #wh, HEAD.MOD #mod,
+                                               CAT [ WH.OR #wh, HEAD.MOD #mod,
                                                      VAL #val ] ],
 					 NON-LOCAL [ SLASH #slash, REL #rel, QUE #que2, YNQ #ynq2 ] ] ],
     ARGS < #ldtr, #rdtr > ].

--- a/matrix-core/matrix.tdl
+++ b/matrix-core/matrix.tdl
@@ -275,16 +275,13 @@ cat-min := avm.
 ; rule's mother's WH is the OR of its daughters.
 
 or-and := avm &
-[ LOGICAL-OR logical-or,
-  LOGICAL-AND logical-and ].
+[ LOGICAL-OR logical-or ].
 
 or-and-minus := or-and &
-[ LOGICAL-OR.BOOL -,
-  LOGICAL-AND.BOOL - ].
+[ LOGICAL-OR.BOOL - ].
 
 or-and-plus := or-and &
-[ LOGICAL-OR.BOOL +,
-  LOGICAL-AND.BOOL + ].
+[ LOGICAL-OR.BOOL + ].
 
 cat := cat-min &
   [ HEAD head-min,
@@ -1970,19 +1967,18 @@ nc-head-filler-phrase := nc-filler-phrase & head-compositional.
 basic-head-subj-phrase := head-valence-phrase & head-compositional &
 			  basic-binary-headed-phrase &
   [ SYNSEM phr-synsem &
-           [ LOCAL.CAT [ WH [ LOGICAL-OR.OR < #or1, #or2 >,
-                              LOGICAL-AND.AND < #and1, #and2 >],
+           [ LOCAL.CAT [ WH [ LOGICAL-OR.OR < #or1, #or2 > ],
                          HC-LIGHT -,
                          VAL [ SPEC #spec,
                                SUBJ < >,
                                COMPS #comps,
                                SPR #spr ] ] ],
-    HEAD-DTR.SYNSEM.LOCAL.CAT [ WH [ LOGICAL-OR #or1, LOGICAL-AND #and1 ],
+    HEAD-DTR.SYNSEM.LOCAL.CAT [ WH [ LOGICAL-OR #or1 ],
                                 VAL [ SPEC #spec, SUBJ < #synsem >,
                                     COMPS #comps,
                                     SPR #spr ] ],
     NON-HEAD-DTR.SYNSEM #synsem & canonical-synsem &
-           [ LOCAL [ CAT [ WH [ LOGICAL-OR #or2, LOGICAL-AND #and2 ],
+           [ LOCAL [ CAT [ WH [ LOGICAL-OR #or2 ],
                            VAL [ SUBJ olist,
                                  COMPS olist,
                                  SPR olist ] ] ],
@@ -2031,7 +2027,7 @@ basic-head-subj-nmc-phrase := head-valence-phrase & basic-binary-headed-phrase &
 basic-head-spec-phrase-super := head-valence-phrase & phrasal &
               binary-headed-phrase &
   [ INFLECTED infl-satisfied,
-    SYNSEM [ LOCAL.CAT [ WH [ LOGICAL-OR.OR < #or1, #or2 >, LOGICAL-AND.AND < #and1, #and2 > ],
+    SYNSEM [ LOCAL.CAT [ WH [ LOGICAL-OR.OR < #or1, #or2 > ],
                          VAL [ SUBJ #subj,
                                COMPS #spcomps,
                                SPR #spr,
@@ -2040,7 +2036,7 @@ basic-head-spec-phrase-super := head-valence-phrase & phrasal &
                          HC-LIGHT - ],
               MODIFIED #modif ],
     HEAD-DTR [ INFLECTED infl-satisfied,
-               SYNSEM [ LOCAL [ CAT [ WH [ LOGICAL-OR #or1, LOGICAL-AND #and1 ],
+               SYNSEM [ LOCAL [ CAT [ WH [ LOGICAL-OR #or1 ],
                                       HEAD #head,
                                       VAL [ SUBJ #subj,
                                             COMPS olist & #comps,
@@ -2051,7 +2047,7 @@ basic-head-spec-phrase-super := head-valence-phrase & phrasal &
                                 CONT.HOOK #hdhook ],
                         MODIFIED #hmodif ] ],
     NON-HEAD-DTR.SYNSEM #synsem &
-     [ LOCAL [ CAT [ WH [ LOGICAL-OR #or2, LOGICAL-AND #and2 ], VAL [ SPEC < [ LOCAL [ CAT [ HEAD #head,
+     [ LOCAL [ CAT [ WH [ LOGICAL-OR #or2 ], VAL [ SPEC < [ LOCAL [ CAT [ HEAD #head,
                                                   VAL.COMPS #comps ],
                                             CONT.HOOK #hdhook ],
                                     MODIFIED #hmodif ] >,
@@ -2079,21 +2075,20 @@ basic-head-spec-phrase := basic-head-spec-phrase-super &
 basic-head-comp-phrase := head-valence-phrase & head-compositional &
               binary-headed-phrase &
   [ SYNSEM phr-synsem-min &
-           [ LOCAL.CAT [ WH [ LOGICAL-OR.OR < #or1, #or2 >,
-                              LOGICAL-AND.AND < #and1, #and2 >],
+           [ LOCAL.CAT [ WH [ LOGICAL-OR.OR < #or1, #or2 > ],
                          VAL [ SUBJ #subj,
                                SPEC #spec,
                                SPR #spr ],
                          POSTHEAD #ph,
                          HC-LIGHT #light ],
              LIGHT #light ],
-    HEAD-DTR.SYNSEM [ LOCAL.CAT [ WH [ LOGICAL-OR #or1, LOGICAL-AND #and1 ],
+    HEAD-DTR.SYNSEM [ LOCAL.CAT [ WH [ LOGICAL-OR #or1 ],
                                   VAL [ SUBJ #subj,
                                         SPEC #spec,
                                         SPR #spr ],
                                   HC-LIGHT #light,
                                   POSTHEAD #ph ]],
-    NON-HEAD-DTR.SYNSEM canonical-synsem & [ LOCAL.CAT.WH [ LOGICAL-OR #or2, LOGICAL-AND #and2 ] ],
+    NON-HEAD-DTR.SYNSEM canonical-synsem & [ LOCAL.CAT.WH [ LOGICAL-OR #or2 ] ],
     C-CONT [ RELS.LIST < >, HCONS.LIST < >, ICONS.LIST < > ] ].
 
 
@@ -2524,12 +2519,11 @@ extracted-adj-first-phrase := extracted-adj-phrase &
 ; OZ 2020-01-25 Adding QUE append to support multiple questions.
 
 basic-head-mod-phrase-simple := head-mod-phrase & binary-headed-phrase &
-  [ SYNSEM [ LOCAL.CAT [ MKG #mkg, WH [ LOGICAL-OR.OR < #or1, #or2 >,
-                                        LOGICAL-AND.AND < #and1, #and2 >] ],
+  [ SYNSEM [ LOCAL.CAT [ MKG #mkg, WH [ LOGICAL-OR.OR < #or1, #or2 > ] ],
              NON-LOCAL [ SLASH.APPEND < #s1, #s2 >,
                          REL 0-alist, QUE.APPEND < #q1, #q2 > ] ],
     HEAD-DTR.SYNSEM
-           [ LOCAL [ CAT [ WH [ LOGICAL-OR #or1, LOGICAL-AND #and1 ],
+           [ LOCAL [ CAT [ WH [ LOGICAL-OR #or1 ],
                            HEAD #head,
                            VAL #val,
                            POSTHEAD #ph,
@@ -2543,7 +2537,7 @@ basic-head-mod-phrase-simple := head-mod-phrase & binary-headed-phrase &
              LIGHT #light,
              MODIFIED #modif ],
     NON-HEAD-DTR.SYNSEM
-           [ LOCAL [ CAT [ WH [ LOGICAL-OR #or2, LOGICAL-AND #and2 ], HEAD [ MOD < [ LOCAL local &
+           [ LOCAL [ CAT [ WH [ LOGICAL-OR #or2 ], HEAD [ MOD < [ LOCAL local &
                                               [ CAT [ HEAD #head,
                                                       VAL #val,
                                                       POSTHEAD #ph,


### PR DESCRIPTION
The WH feature was unnecessarily complex; I was not using the AND portion of it, and it is not very likely it will be needed in the future (at least no indication of it right now).

So it is now of type *logical-or*.

Some time in the future, it may even just become a *bool* and only serve question particles (if the analysis of wh-questions becomes simpler and it is no longer needed in embedded questions) but not yet.