### PR TITLE
Fix 522

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,9 @@
+### Matrix-specific ###
+
 # Ignore cache, testing, build, and other temporary directories
 tests/regression/grammars/
 tests/regression/logs/
 tests/regression/home/current/
-
-# Ignore the compiled python files
-*.pyc
-__pycache__/
-
-# Ignore auto-saves
-*~
 
 # Ignore files under home/gold/testname which are not needed
 tests/regression/home/gold/*/update
@@ -21,3 +16,146 @@ tests/regression/home/gold/*/output
 tests/regression/home/gold/*/item-phenomenon
 tests/regression/home/gold/*/fold
 tests/regression/home/gold/*/analysis
+
+# Compiled grammar files
+*.dat
+*.grm
+
+
+### General ###
+
+# Auto-saves and system files
+*~
+._*
+.DS_Store
+.DS_Store?
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/rtest.py
+++ b/rtest.py
@@ -50,6 +50,14 @@ GRAMMARS_DIR.mkdir(exist_ok=True)
 CURRENT_DIR.mkdir(exist_ok=True)
 LOGS_DIR.mkdir(exist_ok=True)
 
+# These are patterns that rtest should ignore when discovering tests
+
+IGNORE_FILES = {
+    'README',
+    'README.md',
+    '.DS_Store',
+}
+
 
 # MULTIPROCESSING PARAMETERS ##################################################
 
@@ -505,7 +513,7 @@ def _list_files(dir):
     """Map basename to path for files in *dir*."""
     paths = {}
     for path in dir.glob('*'):
-        if path.is_file() and path.name not in ('README', 'README.md'):
+        if path.is_file() and path.name not in IGNORE_FILES:
             paths[path.name] = path
     return paths
 


### PR DESCRIPTION
This does 3 things:

- Expands the `.gitignore` files. This is in fact orthogonal to #522 but it falls under the general topic of better ignoring non-test files.
- Makes it easier to add filenames that should be ignored when discovering tests. There is now a module variable `IGNORE_FILES` for this.
- Add `.DS_Store` to the set of files to ignore.

Fixes #522