### PR TITLE
Reshape adjunct extraction hierarchy

### DIFF
--- a/gmcs/linglib/yes_no_questions.py
+++ b/gmcs/linglib/yes_no_questions.py
@@ -188,7 +188,7 @@ def customize_yesno_questions(mylang, ch, rules, lrules, hierarchies, roots):
                 '''non-local-none :+ [ YNQ.LIST < > ].''', section='addenda')
             mylang.add(
                 '''basic-filler-phrase :+ [ SYNSEM.NON-LOCAL.YNQ.LIST < > ].''', section='addenda')
-            mylang.add('''extracted-adj-phrase-simple :+ 
+            mylang.add('''basic-extracted-adj-phrase :+ 
             [ SYNSEM.NON-LOCAL.YNQ #ynq,
               HEAD-DTR.SYNSEM.NON-LOCAL.YNQ #ynq ].''', section='addenda')
 

--- a/matrix-core/matrix.tdl
+++ b/matrix-core/matrix.tdl
@@ -2447,10 +2447,11 @@ extracted-adj-first-phrase := basic-extracted-adj-phrase &
   [ SYNSEM [ NON-LOCAL.SLASH 
          [ APPEND < #placeholder, #slash >,
 		      PLACEHOLDER #placeholder ] ],
-    HEAD-DTR.SYNSEM.NON-LOCAL.SLASH #slash & LIST < > ].
+    HEAD-DTR.SYNSEM.NON-LOCAL.SLASH #slash ].
 
 extracted-adj-only-phrase := extracted-adj-first-phrase &
-  [ HEAD-DTR.SYNSEM.NON-LOCAL.SLASH.LIST < > ].
+  [ SYNSEM.NON-LOCAL.SLASH.LIST < [ ] >,
+    HEAD-DTR.SYNSEM.NON-LOCAL.SLASH.LIST < > ].
 
 ; ERB 2004-05-10 Bug fix: non-head daughter's MOD..LIGHT value should
 ; be matched to head-daughters LIGHT value.

--- a/matrix-core/matrix.tdl
+++ b/matrix-core/matrix.tdl
@@ -2374,32 +2374,14 @@ head-mod-phrase := head-nexus-rel-phrase &
                                       COMPS #comps, SPEC #spec ],
                       NON-LOCAL [ REL.LIST < > ] ] ].
 
-basic-extracted-adj-phrase := head-mod-phrase & head-only & phrasal.
+;basic-extracted-adj-phrase := head-mod-phrase & head-only & phrasal.
 
-extracted-adj-phrase-simple := basic-extracted-adj-phrase &
+basic-extracted-adj-phrase := head-mod-phrase & head-only & phrasal &
   [ SYNSEM [ LOCAL.CAT [ WH #wh,
                          VAL.SPEC < >,
                          POSTHEAD #ph,
                          MC #mc ],
-	     NON-LOCAL [ QUE #que ] ],
-    HEAD-DTR.SYNSEM canonical-synsem &
-	   [ LOCAL local &
-		   [ CAT [ HEAD verb,
-		           WH #wh,
-		           VAL  [ SUBJ < synsem-min >, SPEC < > ],
-			       POSTHEAD #ph,
-                   MC #mc ],
-                   CONT.HOOK #hook ],
-	     MODIFIED notmod,
-	     NON-LOCAL [ QUE #que ] ],
-    C-CONT [ HOOK #hook,
-         RELS.LIST < >,
-	     HCONS.LIST < >,
-	     ICONS.LIST < > ] ].
-
-extracted-adj-phrase := extracted-adj-phrase-simple &
-  [ SYNSEM [ NON-LOCAL [ SLASH append-list-with-placeholder &
-	                        [ PLACEHOLDER.LIST < [ CAT
+	     NON-LOCAL [ SLASH.PLACEHOLDER.LIST < [ CAT
 		                                            [ HEAD +rp &
 		                                                 [ MOD < [ LOCAL intersective-mod &
                                                                [ CAT [ HEAD #head,
@@ -2410,54 +2392,65 @@ extracted-adj-phrase := extracted-adj-phrase-simple &
                                                       VAL [ SPEC < >,
                                                           SUBJ olist,
                                                           COMPS olist,
-                                                          SPR olist ] ] ] > ] ] ],
+                                                          SPR olist ] ] ] >,
+                    QUE #que,
+                    REL #rel ] ],
     HEAD-DTR.SYNSEM canonical-synsem &
 	   [ LOCAL local &
-		   [ CAT [ HEAD #head,
-		           POSTHEAD #ph,
+		   [ CAT [ HEAD verb,
+		           WH #wh,
+		           VAL  [ SUBJ < synsem-min >, 
+                      SPEC < > ],
+			       POSTHEAD #ph,
                    MC #mc ],
-                   CONT.HOOK #hook,
-                   CTXT #ctxt ],
-	     MODIFIED notmod ] ].
-
-extracted-adj-only-phrase := extracted-adj-phrase-simple &
-  [ SYNSEM [ NON-LOCAL [ SLASH append-list &
-	                        [ LIST < [ CAT
-		                                  [ HEAD +rp &
-		                                         [ MOD < [ LOCAL intersective-mod &
-                                                               [ CAT [ HEAD #head,
-                                                                       POSTHEAD #ph,
-                                                                       MC #mc ],
-                                                                  CONT.HOOK #hook,
-                                                                  CTXT #ctxt ] ] > ],
-                                                      VAL [ SPEC < >,
-                                                          SUBJ olist,
-                                                          COMPS olist,
-                                                          SPR olist ] ] ] > ] ] ],
-    HEAD-DTR.SYNSEM canonical-synsem &
-	   [ LOCAL local &
-		   [ CAT [ HEAD #head,
-		           POSTHEAD #ph,
-                   MC #mc ],
-                   CONT.HOOK #hook,
-                   CTXT #ctxt ],
+                   CONT.HOOK #hook ],
 	     MODIFIED notmod,
-	     NON-LOCAL.SLASH.LIST < > ] ].
+	     NON-LOCAL [ QUE #que, 
+                   REL #rel ] ],
+    C-CONT [ HOOK #hook,
+         RELS.LIST < >,
+	     HCONS.LIST < >,
+	     ICONS.LIST < > ] ].
+
+;extracted-adj-phrase := extracted-adj-phrase-simple &
+;  [ SYNSEM [ NON-LOCAL [ SLASH append-list-with-placeholder &
+;	                        [ PLACEHOLDER.LIST < [ CAT
+;		                                            [ HEAD +rp &
+;		                                                 [ MOD < [ LOCAL intersective-mod &
+;                                                               [ CAT [ HEAD #head,
+;                                                                       POSTHEAD #ph,
+;                                                                       MC #mc ],
+;                                                                  CONT.HOOK #hook,
+;                                                                  CTXT #ctxt ] ] > ],
+;                                                      VAL [ SPEC < >,
+;                                                          SUBJ olist,
+;                                                          COMPS olist,
+;                                                          SPR olist ] ] ] > ] ] ],
+;    HEAD-DTR.SYNSEM canonical-synsem &
+;	   [ LOCAL local &
+;		   [ CAT [ HEAD #head,
+;		           POSTHEAD #ph,
+;                   MC #mc ],
+;                   CONT.HOOK #hook,
+;                   CTXT #ctxt ],
+;	     MODIFIED notmod ] ].
 
 ; OZ 2020-07-01 This requires that any arguments are extracted prior to the adjunct.
-extracted-adj-last-phrase := extracted-adj-phrase &
-  [ SYNSEM [ NON-LOCAL.SLASH append-list &
+extracted-adj-last-phrase := basic-extracted-adj-phrase &
+  [ SYNSEM [ NON-LOCAL.SLASH 
 		      [ APPEND < #slash, #placeholder >,
 		      PLACEHOLDER #placeholder ] ],
     HEAD-DTR.SYNSEM.NON-LOCAL.SLASH #slash & [ LIST cons ] ].
 
 ; OZ 2020-07-01 This requires that any arguments are extracted after the adjunct.
-extracted-adj-first-phrase := extracted-adj-phrase &
-  [ SYNSEM [ NON-LOCAL.SLASH append-list &
-		      [ APPEND < #placeholder, #slash >,
+extracted-adj-first-phrase := basic-extracted-adj-phrase &
+  [ SYNSEM [ NON-LOCAL.SLASH 
+         [ APPEND < #placeholder, #slash >,
 		      PLACEHOLDER #placeholder ] ],
-    HEAD-DTR.SYNSEM.NON-LOCAL.SLASH #slash ].
+    HEAD-DTR.SYNSEM.NON-LOCAL.SLASH #slash & LIST < > ].
 
+extracted-adj-only-phrase := extracted-adj-first-phrase &
+  [ HEAD-DTR.SYNSEM.NON-LOCAL.SLASH.LIST < > ].
 
 ; ERB 2004-05-10 Bug fix: non-head daughter's MOD..LIGHT value should
 ; be matched to head-daughters LIGHT value.

--- a/matrix-core/matrix.tdl
+++ b/matrix-core/matrix.tdl
@@ -2374,7 +2374,11 @@ head-mod-phrase := head-nexus-rel-phrase &
                                       COMPS #comps, SPEC #spec ],
                       NON-LOCAL [ REL.LIST < > ] ] ].
 
-;basic-extracted-adj-phrase := head-mod-phrase & head-only & phrasal.
+; OZ 2020-09-25 Adjunct extraction hierarchy consists of
+; a basic phrase which links the element on the SLASH|MOD list to the head daughter,
+; and the same CAT values are shared by the mother itself.
+; The PLACEHOLDER feature makes it easier to then write rules for
+; flexible word order (and not repeat the MOD constraints).
 
 basic-extracted-adj-phrase := head-mod-phrase & head-only & phrasal &
   [ SYNSEM [ LOCAL.CAT [ WH #wh,
@@ -2412,30 +2416,9 @@ basic-extracted-adj-phrase := head-mod-phrase & head-only & phrasal &
 	     HCONS.LIST < >,
 	     ICONS.LIST < > ] ].
 
-;extracted-adj-phrase := extracted-adj-phrase-simple &
-;  [ SYNSEM [ NON-LOCAL [ SLASH append-list-with-placeholder &
-;	                        [ PLACEHOLDER.LIST < [ CAT
-;		                                            [ HEAD +rp &
-;		                                                 [ MOD < [ LOCAL intersective-mod &
-;                                                               [ CAT [ HEAD #head,
-;                                                                       POSTHEAD #ph,
-;                                                                       MC #mc ],
-;                                                                  CONT.HOOK #hook,
-;                                                                  CTXT #ctxt ] ] > ],
-;                                                      VAL [ SPEC < >,
-;                                                          SUBJ olist,
-;                                                          COMPS olist,
-;                                                          SPR olist ] ] ] > ] ] ],
-;    HEAD-DTR.SYNSEM canonical-synsem &
-;	   [ LOCAL local &
-;		   [ CAT [ HEAD #head,
-;		           POSTHEAD #ph,
-;                   MC #mc ],
-;                   CONT.HOOK #hook,
-;                   CTXT #ctxt ],
-;	     MODIFIED notmod ] ].
 
 ; OZ 2020-07-01 This requires that any arguments are extracted prior to the adjunct.
+; Russian "Kogda kto prishel?" (When did which person came?)
 extracted-adj-last-phrase := basic-extracted-adj-phrase &
   [ SYNSEM [ NON-LOCAL.SLASH 
 		      [ APPEND < #slash, #placeholder >,
@@ -2443,12 +2426,15 @@ extracted-adj-last-phrase := basic-extracted-adj-phrase &
     HEAD-DTR.SYNSEM.NON-LOCAL.SLASH #slash & [ LIST cons ] ].
 
 ; OZ 2020-07-01 This requires that any arguments are extracted after the adjunct.
+; Russian "Kto kogda prishel?" (Which person came when?)
 extracted-adj-first-phrase := basic-extracted-adj-phrase &
   [ SYNSEM [ NON-LOCAL.SLASH 
          [ APPEND < #placeholder, #slash >,
 		      PLACEHOLDER #placeholder ] ],
     HEAD-DTR.SYNSEM.NON-LOCAL.SLASH #slash ].
 
+; OZ 2020-09-25 If there is only one wh-word that can be
+; extracted, this version of the rule should be used.
 extracted-adj-only-phrase := extracted-adj-first-phrase &
   [ SYNSEM.NON-LOCAL.SLASH.LIST < [ ] >,
     HEAD-DTR.SYNSEM.NON-LOCAL.SLASH.LIST < > ].


### PR DESCRIPTION
The hierarchy for adjunct extraction had three supertypes which should perhaps be combined into a single one. Also, *extracted-adj-only-phrase* can in fact inherit from extracted-adj-first-phrase.

There is an [ongoing discussion on whether or not the PLACEHOLDER feature should stay](https://delphinqa.ling.washington.edu/t/finalizing-adjunct-extraction-rules-hierarchy/582/5); if we decide that it should not, that can be a separate PR. The point of this one is to clean up the existing hierarchy a bit.