### PR TITLE
Complementizer: minor supertype change

### DIFF
--- a/gmcs/linglib/clausalcomps.py
+++ b/gmcs/linglib/clausalcomps.py
@@ -238,12 +238,12 @@ def add_complementizer_subtype(cs, mylang, ch, extra):
             mylang.add(
                 typename + ':= [ SYNSEM.LOCAL.CAT.VAL.COMPS < [ LOCAL.CAT.HEAD.EXTRA - ] > ].', merge=True)
     if cs['ques'] == 'ques':  # Should this be disallowed in validation? Or, is this the English "whether"?
-        mylang.add(typename + ':= [ SYNSEM.LOCAL [ CONT.HOOK.INDEX.SF ques,'
+        mylang.add(typename + ':=  basic-wh-word-lex & [ SYNSEM.LOCAL [ CONT.HOOK.INDEX.SF ques,'
                               'CAT.VAL.COMPS.FIRST [ NON-LOCAL.QUE.LIST < > ] ] ].', merge=True)
 
     elif cs['ques'] == 'prop':
         mylang.add(
-            typename + ':= [ SYNSEM.LOCAL.CONT.HOOK.INDEX.SF prop ].', merge=True)
+            typename + ':= basic-non-wh-word-lex & [ SYNSEM.LOCAL.CONT.HOOK.INDEX.SF prop ].', merge=True)
     # OZ 2020-05-09 The below doesn't work because it violates compositionality of semantics. Delete once sure.
 #    else:
 #        mylang.add(typename + ':= [ SYNSEM [ LOCAL [ CAT.VAL.COMPS < [ LOCAL.CONT.HOOK.INDEX.SF #sf ] >,'

--- a/gmcs/linglib/lexbase.py
+++ b/gmcs/linglib/lexbase.py
@@ -48,8 +48,7 @@ COMPLEMENTIZER = '''
                                    [ MOD < > ],
                               VAL [ SPR < >, SPEC < >,
                                     SUBJ < >,
-                                    COMPS < #comp > ] ],
-                    L-QUE - ],
+                                    COMPS < #comp > ] ] ],
            ARG-ST < #comp & [ LOCAL.CAT [ HEAD verb,
                                           VAL [ SUBJ < >,
                                                 COMPS < > ] ] ] > ].'''


### PR DESCRIPTION
A minor change which can be merged in separately from getting rid of lexical threading (which came up while I was working on the latter).

The complementizers (1) should not be constrained to be [ L-QUE - ] at the supertype level; (2) should be either wh or non wh-words, as the rest of the words.