### PR TITLE
Head-complement and adj-head rules LIGHTness

### DIFF
--- a/gmcs/linglib/yes_no_questions.py
+++ b/gmcs/linglib/yes_no_questions.py
@@ -38,6 +38,12 @@ def customize_yesno_questions(mylang, ch, rules, lrules, hierarchies, roots):
 
     qinvverb = ch.get('q-inv-verb')
 
+    if ch.get('q-inv') or (ch.get('q-part') and ch.get('q-part-order') != 'second'):
+        mylang.add(
+            'basic-head-comp-phrase :+ [ SYNSEM [ LOCAL.CAT.HC-LIGHT #light, LIGHT #light ] ].')
+    else:
+        mylang.add('basic-head-comp-phrase :+ [ SYNSEM.LIGHT - ].')
+
     if ch.get('q-inv'):
         comment = \
             'For the analysis of inverted yes-no questions, we add the feature INV.'

--- a/matrix-core/matrix.tdl
+++ b/matrix-core/matrix.tdl
@@ -2058,7 +2058,6 @@ basic-head-comp-phrase := head-valence-phrase & head-compositional &
                                SPR #spr ],
                          POSTHEAD #ph,
                          HC-LIGHT #light ],
-             LIGHT #light,
              MODIFIED #modified ],
     HEAD-DTR.SYNSEM [ LOCAL.CAT [ WH #or1,
                                   VAL [ SUBJ #subj,


### PR DESCRIPTION
I want to make the following changes in order to better be able to use LIGHT for extraction ambiguity curbing (see https://delphinqa.ling.washington.edu/t/using-a-parametrized-list-for-adjunct-extraction-ambiguity/583/12?u=olzama ):

the head complement rule currently identifies the mother's LIGHT with the head daughter's HC-LIGHT. I am actually not too sure what that means, but it appears that it is only crucial for subject-auxiliary inversion and for languages with question particles which act as complementizers. In all other cases, it looks like I can assume that the mother of the head-complement rule is [ LIGHT - ]. This makes sense, too, doesn't it? 

Then I can rely on head-complement being [ LIGHT - ] in most cases to say that subjects are only extracted from [ LIGHT + ] things, and this helps me rule out some of the ambiguity in languages with flexible order of extraction.


The adj-head-phrase says it inherits its HEAD-DTR's LIGHT value, but that does not seem to affect any tests, and I'd like to take it out for similar purposes (I sometimes want to be able to say that adj-head-scopal phrase is [ LIGHT - ], e.g. for Russian where there is a negation adverb but I don't want subjects to be extracted both below and above its attachment).

Does this sound good? Please see the diffs for specifics; there are only a few lines.