### PR TITLE
Use _ instead of % for escaping special characters in the lexicon. LK…

### DIFF
--- a/gmcs/utils.py
+++ b/gmcs/utils.py
@@ -36,7 +36,7 @@ def TDLencode(string):
     val = ''
     for c in string:
         if not (c.isalnum() or ord(c) > 127 or c in ['_', '-', '+', '*']):
-            val += '%' + '%2X' % (ord(c))
+            val += '_' + '%2X' % (ord(c))
         else:
             val += c
 


### PR DESCRIPTION
Whoever would like to contribute, please see the discussion on Discourse: https://delphinqa.ling.washington.edu/t/lkb-fos-in-identifiers/612/12

Long story short, % must be replaced as the escape character in the lexicon. However, I am not so sure which character to use instead. For now, we decided on the underscore but maybe there are better ideas?