### PR TITLE
Fix issue #623

### DIFF
--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -1044,14 +1044,16 @@ def validate_lexicon(ch, vr):
 
                 # TJT 2014-09-03: Adding adjectives and copulas here
                 # or lextype == 'aux': lap: 1/5/11 removed aux to get rid of overzealous validation
-                if lextype in ('verb', 'adj', 'cop'):
+                # LTX 5/11/2022: added aux back, see issue #623 https://github.com/delph-in/matrix/issues/623
+                if lextype in ('verb', 'adj', 'cop', 'aux'):
                     # The head must be defined
                     if not feat.get('head'):
                         mess = 'You must choose where the feature is specified.'
                         vr.err(feat.full_key + '_head', mess)
                     # Index features must be defined on some argument
-                    elif feat.get('head') in ('verb', 'adj', 'cop'):
-                        if feat.get('name') in index_features:
+                    elif feat.get('head') in ('verb', 'adj', 'cop', 'aux'):
+                        # LTX 5/11/2022: CASE feature should also be a nouny feature only
+                        if feat.get('name') in index_features or feat.get('name') in 'case':
                             mess = 'This feature is associated with nouns. ' + \
                                    'Please select one of the NP options to use this feature.'
                             vr.err(feat.full_key + '_head', mess)

--- a/gmcs/linglib/morphotactics.py
+++ b/gmcs/linglib/morphotactics.py
@@ -1228,7 +1228,8 @@ def lrt_validation(lrt, vr, index_feats, choices, incorp=False, inputs=set(), sw
             elif feat['head'] in ['higher', 'lower'] and not choices.get('scale'):
                 vr.err(feat.full_key + '_head',
                        'To use higher/lower ranked NP, please define a scale on the direct-inverse page.')
-            elif feat['head'] == 'verb' and feat.get('name', '') in index_feats:
+            # LTX 5/11/2022: CASE feature should also be a nouny feature only
+            elif feat['head'] == 'verb' and (feat.get('name', '') in index_feats or feat.get('name', '') in 'case'):
                 vr.err(feat.full_key + '_head',
                        'This feature is associated with nouns, ' +
                        'please select one of the NP options.')


### PR DESCRIPTION
This PR improves the validation for nouny features on verby morphology. Please see the discussion in issue #623 for details.

I have attached a [choices file](https://github.com/delph-in/matrix/files/8673700/choice.txt) to try this validation improvement. Demo: https://matrix.ling.washington.edu/ltxom-test/
- Before improvement: validation only blocks PNG features on verbs in Lexicon or Morphology libraries. 
- After improvement: validation blocks PNG or CASE features on verbs or aux in Lexicon or Morphology libraries.

