### PR TITLE
Fix 627

### DIFF
--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -438,6 +438,14 @@ def validate_lexicon(ch, vr):
     seenTrans = False
     seenIntrans = False
 
+    # LTX 2022-05-16: validate if a verb inherits another verb
+    # and has valence, see issue #627
+    for v in ch.get('verb'):
+        if len(vtsts[v.full_key]) > 0 and vtsts[v.full_key][0] != '' and v.get('valence') != '':
+            mess = 'You must either remove the valence of a subtype verb ' \
+                   'or remove the inheritance hierarchy for this verb.'
+            vr.err(v.full_key, mess)
+
     for v in ch.get('verb'):
         st_anc = []  # used to make sure we don't have an lkb err as
         # described in comments above

--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -1095,8 +1095,7 @@ def validate_lexicon(ch, vr):
                     for feat in lt.get('feat'):
                         for parent_feat in parent_features_list:
                             if feat.get('name') == parent_feat.get('name'):
-                                mess = 'Please be aware that this type has a duplicated feature (' + \
-                                       lt.full_key + ': ' + feat.full_key + \
-                                       ') with inheritance hierarchy, ' \
-                                       'which can be factors to create redundant or conflicting grammars.'
+                                mess = 'A value for this feature is already specified on a super type for this ' \
+                                       + lextype + ' class. If the value specified here is conflict with that other' \
+                                              'specification, the grammar will not compile.'
                                 vr.warn(feat.full_key+'_name', mess)

--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -448,7 +448,7 @@ def validate_lexicon(ch, vr):
         if len(vtsts[v.full_key]) > 0 and vtsts[v.full_key][0] != '' and v.get('valence') != '':
             mess = 'You must either remove the valence of a subtype verb ' \
                    'or remove the inheritance hierarchy for this verb.'
-            vr.err(v.full_key, mess)
+            vr.err(v.full_key + '_valence', mess)
 
     for v in ch.get('verb'):
         st_anc = []  # used to make sure we don't have an lkb err as
@@ -1110,4 +1110,4 @@ def validate_lexicon(ch, vr):
                                        lt.full_key + ': ' + feat.full_key + \
                                        ') with inheritance hierarchy, ' \
                                        'which can be factors to create redundant or conflicting grammars.'
-                                vr.warn(lt.full_key, mess)
+                                vr.warn(feat.full_key+'_name', mess)

--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -290,14 +290,7 @@ def validate_lexicon(ch, vr):
                         continue
                     for f in feats[p]:
                         # see if this feat conflicts with what we already know
-                        if f in feats[n.full_key] and feats[p][f] != feats[n.full_key][f]:
-                            # inherited feature conficts with self defined feature
-                            vr.warn(n.full_key + '_feat', "The specification of "+f+"=" +
-                                    str(feats[n.full_key][f])+" may confict with the value" +
-                                    " defined on the supertype " +
-                                    ptype.get('name')+" ("+p+").",
-                                    concat=False)
-                        elif f in inherited_feats[n.full_key] and \
+                        if f in inherited_feats[n.full_key] and \
                                 feats[p][f] != inherited_feats[n.full_key][f]:
                             vr.warn(n.full_key + '_supertypes',
                                     "This inherited specification of "+f+"=" +
@@ -446,8 +439,7 @@ def validate_lexicon(ch, vr):
     # and has valence, see issue #627
     for v in ch.get('verb'):
         if len(vtsts[v.full_key]) > 0 and vtsts[v.full_key][0] != '' and v.get('valence') != '':
-            mess = 'You must either remove the valence of a subtype verb ' \
-                   'or remove the inheritance hierarchy for this verb.'
+            mess = 'A verb class that specifies a value for valence can\'t also inherit a value for valence'
             vr.err(v.full_key + '_valence', mess)
 
     for v in ch.get('verb'):
@@ -1092,9 +1084,6 @@ def validate_lexicon(ch, vr):
     # Only check if there is no cycle in the hierarchy
     if not contain_cycle:
         for lextype in ALL_LEX_TYPES:
-            # skip for nouns since it is check already above
-            if lextype == 'noun':
-                continue
             for lt in ch.get(lextype):
                 # If lt has supertypes
                 lt_supertypes = lt.get('supertypes')

--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -1097,5 +1097,5 @@ def validate_lexicon(ch, vr):
                             if feat.get('name') == parent_feat.get('name'):
                                 mess = 'A value for this feature is already specified on a super type for this ' \
                                        + lextype + ' class. If the value specified here is conflict with that other' \
-                                              'specification, the grammar will not compile.'
+                                              ' specification, the grammar will not compile.'
                                 vr.warn(feat.full_key+'_name', mess)

--- a/gmcs/utils.py
+++ b/gmcs/utils.py
@@ -121,3 +121,18 @@ def has_nmz_ccomp(ch):
             if f['name'] == 'nominalization':
                 return True
     return False
+
+
+'''
+LTX 2022-05-16: 
+** Need to check the hierarchy DOES NOT contain a cycle before using this function **
+Recursively build up a list of features (parent_features_list)
+from a child node to its parent top node. 
+'''
+def recursive_get_supertypes_features(ch, lt, parent_features_list):
+    feats = ch.get(lt).get('feat')
+    for feat in feats:
+        parent_features_list.append(feat)
+    lt_supertypes = ch.get(lt).get('supertypes')
+    if len(lt_supertypes) != 0:
+        recursive_get_supertypes_features(ch, lt_supertypes, parent_features_list)


### PR DESCRIPTION
This PR fixes issue #627 .

There are two improvements:
1. validation reports an error if a verb inherits another verb and has valence. ([lexicon.py line #445-#452](https://github.com/delph-in/matrix/compare/trunk...ltxom:fix-627#diff-73ef70b569a1fbfbf6a4ff518128e11e38ccb20d2db78509f4a6a358d8fa9491R445-R452))
2. validation shows a question mark to warn the user of other duplicated features (maybe different values) with inheritance hierarchy.

For the second improvement, there are [existing codes](https://github.com/delph-in/matrix/blob/trunk/gmcs/linglib/lexicon.py#L259-L262) that are implemented for nouns, but this functionality is tangled with only 'det' and 'noun' POS.

Therefore, I created [a new section](https://github.com/delph-in/matrix/compare/trunk...ltxom:fix-627#diff-73ef70b569a1fbfbf6a4ff518128e11e38ccb20d2db78509f4a6a358d8fa9491R1088-R1113) and [a helper method](https://github.com/delph-in/matrix/compare/trunk...ltxom:fix-627#diff-a52fbfbe26e85fa86a3b0ccde9e13c092b434b19fd5e9639816133205d110a57R124-R138) to check for other POS.

Regression Tests are all passed after these improvements. Here's a [choices file](https://github.com/delph-in/matrix/files/8873207/issue-627-choice.txt) to test (demo in https://matrix.ling.washington.edu/ltxom-test/)


