### PR TITLE
Remove roots.tdl from install.

### DIFF
--- a/install
+++ b/install
@@ -93,7 +93,7 @@ rsync -a -o --exclude={CVS/,.svn/,delphin/,regression_tests/,tests/,sql_profiles
 # create datestamp, matrix-types, and head-types files
 date -u > $tempdir/datestamp
 matrix_core=${CUSTOMIZATIONROOT}/../matrix-core/
-cat $matrix_core/{matrix.tdl,head-types.tdl,roots.tdl,labels.tdl} | grep '^[^;].*:=' | sed 's/ *:=.*//g' | sort | uniq > $tempdir/matrix-types
+cat $matrix_core/{matrix.tdl,head-types.tdl,labels.tdl} | grep '^[^;].*:=' | sed 's/ *:=.*//g' | sort | uniq > $tempdir/matrix-types
 
 # Redirect directory index to cgi script (rather than index.html)
 echo "DirectoryIndex matrix.cgi" >> $tempdir/.htaccess


### PR DESCRIPTION
When trying to run the example command
`matrix.py -C gmcs install username@patas.ling.washington.edu/home/www-matrix/html/username`

There is an error that says the following:
`cat: /home2/username/matrix/gmcs/../matrix-core//roots.tdl: No such file or directory`

This is because roots.tdl has long been deleted/unused so the file is not there.
This change will remove the search for this file so that the install script can run without this warning message.