### PR TITLE
Rpendlet test by gen

### DIFF
--- a/gmcs/generate.py
+++ b/gmcs/generate.py
@@ -83,6 +83,12 @@ def get_sentences_from_lkb_output(output_file,  mrs_files, verb_preds):
     '''parses the output file from lkb after generating sentences to extract the sentence information.'''
     output = open(output_file, 'r')
     sentences = []
+
+     # create an entry in sentences for every mrs pattern in mrs_files
+    for i in range(len(mrs_files)):
+        sentences.append([[mrs_files[i]+":", verb_preds[i][0],
+                               verb_preds[i][1], verb_preds[i][2]], [], [], []])
+
     index = -1
     sentence = parse = mrs = state = ""
     in_output = False
@@ -93,8 +99,6 @@ def get_sentences_from_lkb_output(output_file,  mrs_files, verb_preds):
         # continue
         if line.find("new-pattern") == 0:
             index += 1
-            sentences.append([[mrs_files[index]+":", verb_preds[index][0],
-                               verb_preds[index][1], verb_preds[index][2]], [], [], []])
         elif line.find("start-entry") == 0:
             state = "sentence"
         elif line.find("parse") == 0:

--- a/gmcs/generate.py
+++ b/gmcs/generate.py
@@ -65,8 +65,23 @@ def generate_sentences(grammar, mrs_files, verb_preds, delphin_dir, session):
     lkb_input.close()
     os.remove('lkb_input'+session)
     output.close()
-    output = open('lkb_output'+session, 'r')
 
+    sentences = get_sentences_from_lkb_output('lkb_output'+session, mrs_files, verb_preds)
+    # the structure of this sentences list is
+    # [ 
+    #   [
+    #       [ <mrs_file_name>:, <dictionary_with_verb_predicate_names>, <mrs_template_label>, <mrs_template_file_name> ],
+    #       [ <sentence_generated> ], 
+    #       [ <tree_structure_for_sentences> ], 
+    #       [ <values_for_tags_and_features_in_MRS> ]
+    #   ]
+    # ]
+    # Eg. [[['8098Pattern 1:', {'ITR-VERB1': '_sleep_v_rel'}, 'Intransitive verb phrase', 'itv'], [b'i sleep'], ["&nbsp&nbsp&nbsp&nbsp (S (NP (N ('I'))) (VP ('sleep')))<br>"], ['&nbsp&nbsp&nbsp&nbsp &lt h1,e2:PROP-OR-QUES:TENSE:ASPECT:MOOD,...]
+    return sentences
+
+def get_sentences_from_lkb_output(output_file,  mrs_files, verb_preds):
+    '''parses the output file from lkb after generating sentences to extract the sentence information.'''
+    output = open(output_file, 'r')
     sentences = []
     index = -1
     sentence = parse = mrs = state = ""
@@ -124,14 +139,12 @@ def generate_sentences(grammar, mrs_files, verb_preds, delphin_dir, session):
             mrs += "&nbsp&nbsp&nbsp&nbsp " + \
                 line.strip().replace("<", "&lt ").replace(">", "&gt") + "<br>"
     output.close()
-    os.remove('lkb_output'+session)
+    os.remove(output_file)
     for entry in sentences:
         entry[2] = [clean_tree(s) for s in entry[2]]
     return sentences
 
 # returns a clean version of a tree outputted by the lkb
-
-
 def clean_tree(tree):
     return re.sub(r'\("([^()]+)"\)', r'(@\1@)', tree).replace('"', '').replace('@', "'")
 
@@ -253,6 +266,7 @@ def get_v_predications(grammar_dir, lang):
 
 class Template:
     def __init__(self, file=None):
+        # The file name is expected to be a file listed in web/templates/
         if file:
             pred_re = re.compile(r'#(.*?)#')
             feat_re = re.compile(r'@(.*?)@')


### PR DESCRIPTION
TLDR; The basic functionality of Test By Generation remains the same but we can now see more information even when no sentences are generated.

![Screen Shot 2022-08-08 at 1 41 16 AM](https://user-images.githubusercontent.com/20407310/183380827-6c21b627-96e3-40cb-939f-1fc7e7d1e6e8.png)

There are 3 commits here on this pull request I'll explain each of them.
- [Refactoring generate.py](https://github.com/delph-in/matrix/commit/de72efc8dcc41265e1b23ef74704b13ee25ff025)
This change just extracts out the logic for parsing the lkb output into its a separate function because I will eventually need to parse the ace output which has a different format entirely so I want to be able to swap out the logic for each.
- [Merge branch 'trunk' of](https://github.com/delph-in/matrix/commit/cca270587124e0fe35841187f9dc9e81b72dec08) https://github.com/rosypen/matrix [into rpendl…](https://github.com/delph-in/matrix/commit/cca270587124e0fe35841187f9dc9e81b72dec08)
Simple merge of changes in the trunk branch (which are from my last commit).
- [Populate TestByGeneration page as much as possible](https://github.com/delph-in/matrix/commit/e4732849aafeba22ca3566854bb7af8b888a7c8e)
This enables the Test by Generation page to look like the screenshot above. We can see the Patterns that were tried but still no sentences are generated. (Although I have managed to generate sentences locally, just having issues generating from the website).

This bottom photo is what the Test By Generation page looks like fully populated.

![Screen Shot 2022-08-07 at 11 59 16 PM](https://user-images.githubusercontent.com/20407310/183381789-32c5a1cd-4fed-4418-a183-35bd0f7dc5e3.png)

