### PR TITLE
Fixes bug-635 NON-LOCAL underspecified within clausalmod library.

### DIFF
--- a/gmcs/linglib/clausalmods.py
+++ b/gmcs/linglib/clausalmods.py
@@ -634,7 +634,7 @@ def add_morphological_subord_rel(mylang, cms, ch, rules):
           					        COORD - ] ] ] > ].')
     else:
         supertype = 'morphological-subord-clause-phrase'
-        mylang.add(supertype + ' := unary-phrase &\
+        mylang.add(supertype + ' := unary-phrase & unary-nonloc-phrase &\
     [ SYNSEM [ LOCAL [ CAT [ MC -,\
                             VAL [ SUBJ #subj,\
                                   SPR < >,\


### PR DESCRIPTION
Made it so that morphological-subord-clause-phrase inherits from unary-nonloc-phrase within clausalmods.py to avoid spurious extraction rules.