### PR TITLE
Fix 672 removed redundant line

### DIFF
--- a/gmcs/linglib/adverbs_adpositions.py
+++ b/gmcs/linglib/adverbs_adpositions.py
@@ -11,7 +11,7 @@ from gmcs import constants
 # Constants
 
 HEAD_ADJ = '''my-head-adj-phrase := head-adj-int-phrase &
- [ HEAD-DTR.SYNSEM.LOCAL.CAT [ HEAD +nvr, VAL [ SUBJ clist, COMPS clist ] ],
+ [ HEAD-DTR.SYNSEM.LOCAL.CAT [ HEAD +nvr],
    NON-HEAD-DTR.SYNSEM.LOCAL.CAT [ HEAD +jrp, VAL.COMPS < > ] ].
  '''
 


### PR DESCRIPTION
Removed a redundant line in adverbs_adpositions.py to ensure that the regression test that should have caught the original bug actually catches it.