### PR TITLE
Fix for bug 589

### DIFF
--- a/gmcs/linglib/adnominal_possession.py
+++ b/gmcs/linglib/adnominal_possession.py
@@ -1369,7 +1369,7 @@ def customize_possessor_pron_lexicon(strat, mylang, ch, lexicon, strat_name, str
         agr_prefix = 'SYNSEM.LOCAL.CAT.VAL.SPEC.FIRST.LOCAL.CONT.HOOK.INDEX.PNG'
 
         mylang.add(noun_type+' := \
-                        [ SYNSEM.LOCAL [ CAT [ HEAD.POSSESSOR possessor-pron-'+strat_num+',\
+                        [ SYNSEM.LOCAL [ CAT [ HEAD [ MOD < >, POSSESSOR possessor-pron-'+strat_num+'],\
                                                VAL.SPEC < > ],\
                                          CONT [ RELS.LIST  < #altkeyrel >,\
                                                   HCONS.LIST < > ] ] ].')

--- a/gmcs/linglib/adverbs_adpositions.py
+++ b/gmcs/linglib/adverbs_adpositions.py
@@ -10,16 +10,6 @@ from gmcs import constants
 
 # Constants
 
-HEAD_ADJ = '''my-head-adj-phrase := head-adj-int-phrase &
- [ HEAD-DTR.SYNSEM.LOCAL.CAT [ HEAD +nvr],
-   NON-HEAD-DTR.SYNSEM.LOCAL.CAT [ HEAD +jrp, VAL.COMPS < > ] ].
- '''
-
-ADJ_HEAD = '''my-adj-head-phrase := adj-head-int-phrase &
- [ HEAD-DTR.SYNSEM [ LOCAL.CAT [ HEAD +nvr ] ],
-   NON-HEAD-DTR.SYNSEM.LOCAL.CAT [ HEAD +jrp, VAL.COMPS < > ] ].
- '''
-
 
 def customize_adv_adp(ch, mylang, rules):
     # need to handle also adjectives here
@@ -27,8 +17,7 @@ def customize_adv_adp(ch, mylang, rules):
         mylang.add_literal(';;; Head Adjunct rules', section='phrases')
         mylang.add_literal(
             '; For intersective adjuncts with underspecified attachment locations:', section='phrases')
-        mylang.add(HEAD_ADJ, section='phrases')
-        mylang.add(ADJ_HEAD, section='phrases')
         mylang.add('bare-np-phrase := [ SYNSEM.LIGHT - ].')
-        rules.add('head-adj := my-head-adj-phrase.')
-        rules.add('adj-head := my-adj-head-phrase.')
+        rules.add('head-adj := head-adj-int-phrase.')
+        rules.add('adj-head := adj-head-int-phrase.')
+       

--- a/gmcs/linglib/lexical_items.py
+++ b/gmcs/linglib/lexical_items.py
@@ -1080,14 +1080,11 @@ def customize_adjs(mylang, ch, lexicon, hierarchies, rules):
                    section='lexrules')
 
     # Add the proper syntactic rules to rules.tdl
-    from gmcs.linglib.adverbs_adpositions import HEAD_ADJ, ADJ_HEAD
     if adj_rules['head_adj']:
-        mylang.add(HEAD_ADJ, section='phrases')
-        rules.add("head-adj := my-head-adj-phrase.")
+        rules.add("head-adj := head-adj-int-phrase.")
 
     if adj_rules['adj_head']:
-        mylang.add(ADJ_HEAD, section='phrases')
-        rules.add("adj-head := my-adj-head-phrase.")
+        rules.add("adj-head := adj-head-int-phrase.")
 
     # Add the lexical entries to lexicon.tdl
     lexicon.add_literal(';;; Adjectives')

--- a/gmcs/linglib/yes_no_questions.py
+++ b/gmcs/linglib/yes_no_questions.py
@@ -71,7 +71,7 @@ def customize_yesno_questions(mylang, ch, rules, lrules, hierarchies, roots):
 			same-posthead-lex-rule &
                         constant-lex-rule &
       [ INFLECTED #infl,
-        SYNSEM [ LOCAL.CAT [ HEAD verb & [ INV + ],
+        SYNSEM [ LOCAL.CAT [ HEAD verb & [ MOD < >, INV + ],
                              VAL [ COMPS < #subj . #comps >,
                                      SUBJ < >,
                                      SPR #spr,


### PR DESCRIPTION
Removed the my- rules and added MOD < > to the appropriate places to prevent extraneous parses involving the head-adj rules as discussed in https://github.com/delph-in/matrix/issues/589