### PR TITLE
Fix trans and intrans cases getting stuck in verification

### DIFF
--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -1013,16 +1013,17 @@ def validate_lexicon(ch, vr):
     for p in ch.patterns():
         p = p[0].split(',')
         c = p[0].split('-')
-        cases += [c[0], c[1]] if len(c) > 1 else [c[0]]
-    cases.remove('trans')
-    cases.remove('intrans')
+        if c[0] != 'trans' and c[0] != 'intrans':
+            cases.append(c[0])
+        if len(c) > 1:
+            cases.append(c[1])
     # if adpositions are not marked optional...
     if ch.has_adp_case() and not ch.has_optadp_case():
         for case in cases:
             # each case must be contributed by an adposition or noun case somewhere.
             if not (ch.has_adp_case(case) or ch.has_noun_case(case)):
                 if case not in not_covered:
-                    not_covered += [case]
+                    not_covered.append(case)
         if len(not_covered) > 0:
             mess = 'You have case-marking adpositions marked non-optional, but not all ' + \
                    'core cases are contributed by adpositions, inflection, or lexical types. ' + \


### PR DESCRIPTION
This issue occurs when a grammar has both required case-marking adpositions and complementizers. The `trans` case would be inserted multiple times into the `cases` list, which causes verification to fail on the customization pages.