### PR TITLE
Document query by name instead of id

### DIFF
--- a/web/draw.js
+++ b/web/draw.js
@@ -55,7 +55,7 @@ function draw_hierarchy(type) {
     // input without being saved yet.
     //
     // basically, if we seen parans in the value, we'll assume this is the case
-    var lsuper = document.getElementById(lts[i]+"_supertypes_multitext");
+    var lsuper = document.getElementsByName(lts[i]+"_supertypes")[0]
     if (lsuper.value == "") {
       anchored = true;
       ltsups[i] = type 

--- a/web/matrixdef
+++ b/web/matrixdef
@@ -2048,7 +2048,7 @@ Label "</div>"
 Section nominalclause "Nominalized Clauses"
 
 Label "<p>If your language uses nominalization in the context of clausal complements
-and/or clausal modifiers, define the nomminalization strategies here. They will then be available on the Clausal Complements, Clausal Modifers, and Morphology pages.</p>"
+and/or clausal modifiers, define the nominalization strategies here. They will then be available on the Clausal Complements, Clausal Modifers, and Morphology pages.</p>"
 
 BeginIter ns{i} "a Nominalization Strategy" 1
 


### PR DESCRIPTION
#690 Querying by the name of the select instead of the id of the select allows for finding the select whether it is hidden or not and accessing the chosen value if any of the supertype options. The picture below shows output for the following choices. This is static proof but it displays without opening any of the lexical entries first. 

section=lexicon
  noun1_name=common
    noun1_feat1_name=person
    noun1_feat1_value=3rd
  noun1_det=obl
    noun1_stem1_orth=cat
    noun1_stem1_pred=_cat_n_rel
  noun2_name=1sg-pronoun
    noun2_feat1_name=person
    noun2_feat1_value=1st
    noun2_feat2_name=number
    noun2_feat2_value=sg
  noun2_det=imp
    noun2_stem1_orth=I
    noun2_stem1_pred=_pronoun_n_rel
  noun3_name=test
  noun3_det=obl
    noun3_stem1_orth=test
    noun3_stem1_pred=_test_n_rel
  noun4_name=multi
  noun4_supertypes=noun1, noun3
    noun4_stem1_orth=multi
    noun4_stem1_pred=_multi_n_rel

![Screen Shot 2024-09-16 at 8 42 15 PM](https://github.com/user-attachments/assets/e37d0024-81c0-464a-bb2b-a62dae490d6e)
