### PR TITLE
#712 Trigger rules empty copulas

### DIFF
--- a/gmcs/linglib/lexical_items.py
+++ b/gmcs/linglib/lexical_items.py
@@ -1167,8 +1167,12 @@ def customize_cops(mylang, ch, lexicon, hierarchies, trigger):
                 name = stem.get('name')
                 typedef = TDLencode(name) + ' := ' + ctype + ' & \
                         [ STEM < "' + orthstr + '" > ].'
-                lexicon.add(typedef)               
-                
+                                
+                grdef= TDLencode(orth) +'_gr := arg0e_gtr & \
+                            [ CONTEXT [ RELS.LIST < [ PRED "~._a_" ] > ], \
+                                FLAGS.TRIGGER "' + TDLencode(orth) + '" ].'
+                trigger.add(grdef)                
+                lexicon.add(typedef)             
 
 def customize_adpositions(mylang, lexicon, ch, hierarchies):
     mylang.add(lexbase.ADP_LEX)

--- a/matrix.cgi
+++ b/matrix.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env /usr/local/python-virt/matrix/bin/python3
 
 # $Id: matrix.cgi,v 1.27 2008-09-09 08:37:52 sfd Exp $
 

--- a/matrix.cgi
+++ b/matrix.cgi
@@ -49,7 +49,6 @@ if os.path.exists('sessions/choices'):
 matrixdef = MatrixDefFile('web/matrixdef')
 
 form_data = cgi.FieldStorage()
-print("form_data.keys()=", form_data.keys(), file=sys.stderr)
 
 # see if we are in debug mode
 debug = 'debug' in form_data and form_data['debug'].value in ('true', 'True')
@@ -139,7 +138,7 @@ if 'choices' in form_data:
             with open(choices, 'r', encoding=READ_ENCODING) as f:
                 data = f.read()
         elif choices.startswith('collage/'):
-            # Get choices files from COLLAGE
+            # Get choices files from CoLLAGE
             # should be 3 or 7 letter keys... doesn't work for other length keys
             if len(choices) in ((len('collage/') + 3), (len('collage/') + 7)):
                 import urllib.request
@@ -243,9 +242,7 @@ elif 'customize' in form_data:
 
         # Create the customized grammar
         try:
-            print("in matrix.cgi, about to customize matrix", file=sys.stderr)
             grammar_dir = customize_matrix(session_path, arch_type)
-            print("in matrix.cgi, done customizing matrix", file=sys.stderr)
         except:
             exc = sys.exc_info()
             matrixdef.customize_error_page(choices_path,

--- a/matrix.cgi
+++ b/matrix.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/local/python-virt/matrix/bin/python3
+#!/usr/bin/env python3
 
 # $Id: matrix.cgi,v 1.27 2008-09-09 08:37:52 sfd Exp $
 
@@ -49,6 +49,7 @@ if os.path.exists('sessions/choices'):
 matrixdef = MatrixDefFile('web/matrixdef')
 
 form_data = cgi.FieldStorage()
+print("form_data.keys()=", form_data.keys(), file=sys.stderr)
 
 # see if we are in debug mode
 debug = 'debug' in form_data and form_data['debug'].value in ('true', 'True')
@@ -138,7 +139,7 @@ if 'choices' in form_data:
             with open(choices, 'r', encoding=READ_ENCODING) as f:
                 data = f.read()
         elif choices.startswith('collage/'):
-            # Get choices files from CoLLAGE
+            # Get choices files from COLLAGE
             # should be 3 or 7 letter keys... doesn't work for other length keys
             if len(choices) in ((len('collage/') + 3), (len('collage/') + 7)):
                 import urllib.request
@@ -242,7 +243,9 @@ elif 'customize' in form_data:
 
         # Create the customized grammar
         try:
+            print("in matrix.cgi, about to customize matrix", file=sys.stderr)
             grammar_dir = customize_matrix(session_path, arch_type)
+            print("in matrix.cgi, done customizing matrix", file=sys.stderr)
         except:
             exc = sys.exc_info()
             matrixdef.customize_error_page(choices_path,


### PR DESCRIPTION
Trigger rules created found here:

 ;;; -*- Mode: TDL; Coding: utf-8 -*-
;;; Semantically Empty Lexical Entries

aux_gr := arg0e_gtr &
  [ CONTEXT.RELS.LIST < [ PRED "non_existing_rel" ] >,
    FLAGS.TRIGGER "aux" ].

is_gr := arg0e_gtr &
  [ CONTEXT.RELS.LIST < [ PRED "~._a_" ] >,
    FLAGS.TRIGGER "is" ].

are_gr := arg0e_gtr &
  [ CONTEXT.RELS.LIST < [ PRED "~._a_" ] >,
    FLAGS.TRIGGER "are" ].


 for 
[choices (11).txt](https://github.com/user-attachments/files/17023142/choices.11.txt)
