### PR TITLE
698 validation

### DIFF
--- a/gmcs/linglib/lexical_items.py
+++ b/gmcs/linglib/lexical_items.py
@@ -1167,8 +1167,12 @@ def customize_cops(mylang, ch, lexicon, hierarchies, trigger):
                 name = stem.get('name')
                 typedef = TDLencode(name) + ' := ' + ctype + ' & \
                         [ STEM < "' + orthstr + '" > ].'
-                lexicon.add(typedef)               
-                
+                                
+                grdef= TDLencode(orth) +'_gr := arg0e_gtr & \
+                            [ CONTEXT [ RELS.LIST < [ PRED "~._a_" ] > ], \
+                                FLAGS.TRIGGER "' + TDLencode(orth) + '" ].'
+                trigger.add(grdef)                
+                lexicon.add(typedef)             
 
 def customize_adpositions(mylang, lexicon, ch, hierarchies):
     mylang.add(lexbase.ADP_LEX)

--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 from gmcs.linglib import case
 #from gmcs.linglib import lexical_items
 from gmcs.utils import get_name
+from gmcs import constants
+from gmcs.constants import MTRX_FRONT
 from gmcs.choices import ChoiceDict
 from gmcs.linglib.lexbase import LexicalType, PositionClass
 from gmcs.linglib.lexbase import ALL_LEX_TYPES
@@ -406,6 +408,12 @@ def validate_lexicon(ch, vr):
             mess = 'A noun defined as %s taking a determiner is unusable %s' + \
                    'without any determiners defined.'
             vr.warn(n.full_key + '_det', mess % message_map[det])
+            
+        q = n.get('inter')
+        wh_q1 = ch.get(MTRX_FRONT)
+        if q == 'on' and (not wh_q1):
+            vr.warn(n.full_key + '_inter', 'A noun defined as a question pronoun is unusable ' + \
+                    'without any constituent question selections.')
 
         for stem in s:
             orth = stem.get('orth')

--- a/gmcs/linglib/morphotactics.py
+++ b/gmcs/linglib/morphotactics.py
@@ -1232,32 +1232,6 @@ def lrt_validation(lrt, vr, index_feats, choices, incorp=False, inputs=set(), sw
     #  vr.err(lrt.full_key + '_supertypes',
     #         'You must select a supertype for every lexical rule type.')
     # any features on an LR need a name and value (and head for verbs)
-    for feat in lrt.get('feat', []):
-        if 'name' not in feat:
-            vr.err(feat.full_key + '_name',
-                   'You must choose which feature you are specifying.')
-        if 'value' not in feat:
-            vr.err(feat.full_key + '_value',
-                   'You must choose a value for each feature you specify.')
-        # TJT 2014-08-22: check head for adjectives and incorporated stems
-        if lrt.full_key.startswith('verb-pc') or \
-                lrt.full_key.startswith('adj-pc') or \
-            'is-lrt' in lrt.full_key:
-            if 'head' not in feat:
-                vr.err(feat.full_key + '_head',
-                       'You must choose where the feature is specified.')
-            elif feat['head'] in ['higher', 'lower'] and not choices.get('scale'):
-                vr.err(feat.full_key + '_head',
-                       'To use higher/lower ranked NP, please define a scale on the direct-inverse page.')
-            elif feat['head'] == 'verb' and (feat.get('name', '') in 'case'):
-                vr.err(feat.full_key + '_head',
-                       'This feature is associated with nouns, ' +
-                       'please select one of the NP options.')
-
-        # MTH 2017-11-27: check to make sure that only one evidential value is selected
-        if feat['name'] == 'evidential' and len(feat.get('value').split(',')) > 1:
-            vr.err(feat.full_key + '_value',
-                   'Choose only one evidential term.')
 
     # TJT 2015-02-02: Any given LRT should be either inflecting or non-inflecting
     inflecting_count = len([_f for _f in [lri.get(

--- a/gmcs/validate.py
+++ b/gmcs/validate.py
@@ -1020,6 +1020,10 @@ def validate_yesno_questions(ch, vr):
                    'for yes-no questions, you must specify ' + \
                    'where the question particle appears.'
             vr.err('q-part-order', mess)
+        if not ch.get('q-particle'):
+            mess = 'If you chose the question particle strategy for yes-no questions, ' + \
+                   'you must specify at least one question particle.'
+            vr.err('q-particle', mess)
         for qpart in ch.get('q-particle'):
             if not qpart['orth']:
                 mess = 'If you chose the question particle strategy ' + \
@@ -1283,6 +1287,46 @@ def validate_features(ch, vr):
                     value_list += \
                         [[feat.full_key + '_value',
                             feat.get('name'), feat.get('value')]]
+                            
+                    if 'name' not in feat:
+                        vr.err(feat.full_key + '_name',
+                            'You must choose which feature you are specifying.')
+                    if 'value' not in feat:
+                        vr.err(feat.full_key + '_value',
+                            'You must choose a value for each feature you specify.')
+                            
+                    # MTH 2017-11-27: check to make sure that only one evidential value is selected
+                    if feat['name'] == 'evidential' and len(feat.get('value').split(',')) > 1:
+                        vr.err(feat.full_key + '_value',
+                               'Choose only one evidential term.')
+                            
+                    if lrt.full_key.startswith('verb-pc') or \
+                            lrt.full_key.startswith('adj-pc') or \
+                        'is-lrt' in lrt.full_key:
+                        if 'head' not in feat:
+                            vr.err(feat.full_key + '_head',
+                                   'You must choose where the feature is specified.')
+                        elif feat['head'] in ['higher', 'lower'] and not choices.get('scale'):
+                            vr.err(feat.full_key + '_head',
+                                   'To use higher/lower ranked NP, please define a scale on the direct-inverse page.')
+                        elif feat['head'] == 'verb' and (feat.get('name', '') in 'case'):
+                            vr.err(feat.full_key + '_head',
+                                   'This feature is associated with nouns, ' +
+                                   'please select one of the NP options.')
+                        
+                        name = feat['name']
+                        head = feat['head']
+                        other_features = ch.get('feature')          
+                    
+                        for f in list(other_features):
+                            if name == f['name']:
+                                cat = f['cat']
+                                y1 = (cat == 'noun')
+                                y2 = (head in ['subj', 'obj', 'noun'])
+                                if cat == 'noun' and not head in ['subj', 'obj', 'noun']:
+                                    vr.err(feat.full_key + '_head', 'This feature is associated with nouns, please select one of the NP options.')   
+                                if cat == 'verb' and not head in ['verb']:
+                                    vr.err(feat.full_key + '_head', 'This feature is associated with verbs, please select on of the VP options.')
 
     for context in ch.get('context', []):
         for feat in context.get('feat', []):

--- a/matrix.cgi
+++ b/matrix.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env /usr/local/python-virt/matrix/bin/python3
 
 # $Id: matrix.cgi,v 1.27 2008-09-09 08:37:52 sfd Exp $
 

--- a/matrix.cgi
+++ b/matrix.cgi
@@ -49,7 +49,6 @@ if os.path.exists('sessions/choices'):
 matrixdef = MatrixDefFile('web/matrixdef')
 
 form_data = cgi.FieldStorage()
-print("form_data.keys()=", form_data.keys(), file=sys.stderr)
 
 # see if we are in debug mode
 debug = 'debug' in form_data and form_data['debug'].value in ('true', 'True')
@@ -139,7 +138,7 @@ if 'choices' in form_data:
             with open(choices, 'r', encoding=READ_ENCODING) as f:
                 data = f.read()
         elif choices.startswith('collage/'):
-            # Get choices files from COLLAGE
+            # Get choices files from CoLLAGE
             # should be 3 or 7 letter keys... doesn't work for other length keys
             if len(choices) in ((len('collage/') + 3), (len('collage/') + 7)):
                 import urllib.request
@@ -243,9 +242,7 @@ elif 'customize' in form_data:
 
         # Create the customized grammar
         try:
-            print("in matrix.cgi, about to customize matrix", file=sys.stderr)
             grammar_dir = customize_matrix(session_path, arch_type)
-            print("in matrix.cgi, done customizing matrix", file=sys.stderr)
         except:
             exc = sys.exc_info()
             matrixdef.customize_error_page(choices_path,

--- a/matrix.cgi
+++ b/matrix.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env /usr/local/python-virt/matrix/bin/python3
+#!/usr/bin/env python3
 
 # $Id: matrix.cgi,v 1.27 2008-09-09 08:37:52 sfd Exp $
 
@@ -49,6 +49,7 @@ if os.path.exists('sessions/choices'):
 matrixdef = MatrixDefFile('web/matrixdef')
 
 form_data = cgi.FieldStorage()
+print("form_data.keys()=", form_data.keys(), file=sys.stderr)
 
 # see if we are in debug mode
 debug = 'debug' in form_data and form_data['debug'].value in ('true', 'True')
@@ -138,7 +139,7 @@ if 'choices' in form_data:
             with open(choices, 'r', encoding=READ_ENCODING) as f:
                 data = f.read()
         elif choices.startswith('collage/'):
-            # Get choices files from CoLLAGE
+            # Get choices files from COLLAGE
             # should be 3 or 7 letter keys... doesn't work for other length keys
             if len(choices) in ((len('collage/') + 3), (len('collage/') + 7)):
                 import urllib.request
@@ -242,7 +243,9 @@ elif 'customize' in form_data:
 
         # Create the customized grammar
         try:
+            print("in matrix.cgi, about to customize matrix", file=sys.stderr)
             grammar_dir = customize_matrix(session_path, arch_type)
+            print("in matrix.cgi, done customizing matrix", file=sys.stderr)
         except:
             exc = sys.exc_info()
             matrixdef.customize_error_page(choices_path,

--- a/tests/unit/choices_test.py
+++ b/tests/unit/choices_test.py
@@ -1,3 +1,7 @@
+'''
+Run these tests with `python -m tests.unit.choices_test` from the matrix directory.
+'''
+
 import unittest
 from gmcs.choices import ChoicesFile
 from gmcs.choices import ChoicesFileParseError

--- a/tests/unit/morphotactics_test.py
+++ b/tests/unit/morphotactics_test.py
@@ -1,18 +1,24 @@
+'''
+Run these tests with `python -m tests.unit.morphotactics_test` from the matrix directory.
+
+TODO: This entire test class needs updating as morphotactics.py no longer uses 
+many of the types required in these tests.
+'''
+
 import unittest
 from gmcs import choices
 from gmcs.linglib import morphotactics
 
-
-class TestMorphotactics(unittest.TestCase):
-    def test_is_slot(self):
-        # for brevity
-        i_s = morphotactics.is_slot
-        self.assertEqual(i_s(''), False)
-        self.assertEqual(i_s('verb-slot1'), True)
-        self.assertEqual(i_s('verb-slot1_name'), False)
-        self.assertEqual(i_s('verb'), False)
-        self.assertEqual(i_s('slot1'), False)
-        self.assertEqual(i_s('verb-slot42'), True)
+# class TestMorphotactics(unittest.TestCase):
+    # def test_is_slot(self):
+    #     # for brevity
+    #     i_s = morphotactics.is_slot
+    #     self.assertEqual(i_s(''), False)
+    #     self.assertEqual(i_s('verb-slot1'), True)
+    #     self.assertEqual(i_s('verb-slot1_name'), False)
+    #     self.assertEqual(i_s('verb'), False)
+    #     self.assertEqual(i_s('slot1'), False)
+    #     self.assertEqual(i_s('verb-slot42'), True)
 
     # def test_slot_inputs(self):
     #  s_i = morphotactics.slot_inputs
@@ -23,307 +29,307 @@ class TestMorphotactics(unittest.TestCase):
     #  # two inputs
     #  self.assertEqual(s_i(ch['verb-slot1']), ('verb1','verb2'))
 
-    def test_create_preceeds_dict(self):
-        # no slots
-        choices = customize.choices.ChoicesFile()
-        choices.load_choices(lextypes)
-        self.assertEqual(morphotactics.create_preceeds_dict(choices), {})
-        # single slot
-        choices = customize.choices.ChoicesFile()
-        choices.load_choices(lextypes + simple_no_orth)
-        self.assertEqual(morphotactics.create_preceeds_dict(choices),
-                         {'noun-slot1': set(['noun1'])})
-        # two morphemes (no different)
-        choices = customize.choices.ChoicesFile()
-        choices.load_choices(lextypes + two_morphemes)
-        self.assertEqual(morphotactics.create_preceeds_dict(choices),
-                         {'noun-slot1': set(['noun1'])})
-        # competing slots
-        choices = customize.choices.ChoicesFile()
-        choices.load_choices(lextypes + competing_slots)
-        self.assertEqual(morphotactics.create_preceeds_dict(choices),
-                         {'noun-slot1': set(['noun1']),
-                          'noun-slot2': set(['noun1'])})
-        # sequential slots
-        choices = customize.choices.ChoicesFile()
-        choices.load_choices(lextypes + sequential_slots)
-        self.assertEqual(morphotactics.create_preceeds_dict(choices),
-                         {'noun-slot1': set(['noun1']),
-                          'noun-slot2': set(['noun-slot1', 'noun1'])})
-        # multiple basetypes, multiple inputs
-        choices = customize.choices.ChoicesFile()
-        choices.load_choices(lextypes + sequential_verb_slots)
-        self.assertEqual(morphotactics.create_preceeds_dict(choices),
-                         {'verb-slot1': set(['verb1', 'verb2']),
-                          'verb-slot2': set(['verb-slot1', 'verb1', 'verb2']),
-                          'verb-slot3': set(['verb-slot1', 'verb-slot2',
-                                             'verb1', 'verb2'])})
-
-    # def test_disjunctive_typename(self):
-    #  # for brevity
-    #  dtname = morphotactics.disjunctive_typename
-    #  ch = customize.choices.ChoicesFile()
-    #  ch['a1_name'] = 'a'
-    #  ch['b1_name'] = 'b'
-    #  ch['c1_name'] = 'c'
-
-    #  self.assertEqual(dtname([], ch), '')
-    #  self.assertEqual(dtname(sorted(['a1']), ch), 'a')
-    #  self.assertEqual(dtname(sorted(['a1','b1']), ch), 'a-or-b')
-    #  self.assertEqual(dtname(sorted(['a1','b1','c1']), ch), 'a-or-b-or-c')
-
-    def test_all_inputs(self):
-        # for brevity
-        ai = morphotactics.all_inputs
-        s = sorted
-
-        def prep_lrs(choice_lines):
-            ch = customize.choices.ChoicesFile()
-            ch.load_choices(choice_lines)
-            preceeds = morphotactics.create_preceeds_dict(ch)
-            lrs = morphotactics.create_lexical_rules(ch, preceeds)
-            return lrs, preceeds, ch
-        # no inputs
-        lrs, preceeds, ch = prep_lrs(lextypes)
-        self.assertEqual(ai('noun1', lrs, preceeds), [])
-        self.assertEqual(ai('NOSUCH', lrs, preceeds), [])
-        # one input
-        lrs, preceeds, ch = prep_lrs(lextypes + simple_no_orth)
-        self.assertEqual(ai('noun1', lrs, preceeds), [])
-        self.assertEqual(ai('noun-slot1', lrs, preceeds), ['noun1'])
-        # multiple inputs
-        lrs, preceeds, ch = prep_lrs(lextypes + multiple_basetypes)
-        self.assertEqual(s(ai('verb-slot1', lrs, preceeds)),
-                         ['verb1', 'verb2'])
-        # multiple slots
-        lrs, preceeds, ch = prep_lrs(lextypes + competing_slots)
-        self.assertEqual(ai('noun-slot1', lrs, preceeds), ['noun1'])
-        self.assertEqual(ai('noun-slot2', lrs, preceeds), ['noun1'])
-        # sequential
-        lrs, preceeds, ch = prep_lrs(lextypes + sequential_verb_slots)
-        self.assertEqual(s(ai('verb-slot1', lrs, preceeds)),
-                         ['verb1', 'verb2'])
-        self.assertEqual(s(ai('verb-slot2', lrs, preceeds)), s(['verb1', 'verb2',
-                                                                'verb-slot1']))
-
-    def test_sequential(self):
-        # for brevity
-        seq = morphotactics.sequential
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + con_dis_junctive)
-        preceeds = morphotactics.create_preceeds_dict(ch)
-        self.assertEqual(seq('verb-slot1', 'verb-slot2', preceeds), False)
-        self.assertEqual(seq('verb-slot2', 'verb-slot1', preceeds), False)
-        self.assertEqual(seq('verb-slot1', 'verb-slot3', preceeds), True)
-        self.assertEqual(seq('verb-slot3', 'verb-slot1', preceeds), True)
-        self.assertEqual(seq('verb-slot2', 'verb-slot3', preceeds), True)
-        self.assertEqual(seq('verb-slot3', 'verb-slot2', preceeds), True)
-        self.assertEqual(seq('verb-slot3', 'verb-slot4', preceeds), True)
-        self.assertEqual(seq('verb-slot4', 'verb-slot3', preceeds), True)
-        self.assertEqual(seq('verb-slot1', 'verb-slot4', preceeds), True)
-        self.assertEqual(seq('verb-slot4', 'verb-slot1', preceeds), True)
-        self.assertEqual(seq('verb-slot4', 'verb-slot5', preceeds), False)
-        self.assertEqual(seq('verb-slot5', 'verb-slot4', preceeds), False)
-        self.assertEqual(seq('verb-slot1', 'verb-slot1', preceeds), False)
-        self.assertEqual(seq('verb-slot42', 'verb-slot99', preceeds), False)
-
-    def test_ordered_constraints(self):
-        # for brevity
-        oc = morphotactics.ordered_constraints
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + extended_con_dis_junctive2)
-        preceeds = morphotactics.create_preceeds_dict(ch)
-        # one slot
-        self.assertEqual(oc(['verb-slot1'], preceeds), ['verb-slot1'])
-        # nonsequential, ordered by name
-        self.assertEqual(oc(['verb-slot1', 'verb-slot2'], preceeds),
-                         ['verb-slot1', 'verb-slot2'])
-        # nonsequential, not ordered by name
-        self.assertEqual(oc(['verb-slot2', 'verb-slot1'], preceeds),
-                         ['verb-slot1', 'verb-slot2'])
-        # sequential
-        self.assertEqual(oc(['verb-slot4', 'verb-slot1'], preceeds),
-                         ['verb-slot1', 'verb-slot4'])
-        # sequential and nonsequential
-        self.assertEqual(oc(['verb-slot7', 'verb-slot5', 'verb-slot4', 'verb-slot6'],
-                            preceeds),
-                         ['verb-slot4', 'verb-slot5', 'verb-slot6', 'verb-slot7'])
-
-    def test_minimal_flag_set(self):
-        # for brevity
-        s = sorted
-        mfs = morphotactics.minimal_flag_set
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + con_dis_junctive)
-        preceeds = morphotactics.create_preceeds_dict(ch)
-        # no constraints
-        self.assertEqual(mfs({}, preceeds), [])
-        # single constraint (a or b forces c)
-        self.assertEqual(mfs(('verb-slot3',), preceeds), [('verb-slot3',)])
-        # two constraints, sequential
-        self.assertEqual(s(mfs(('verb-slot3', 'verb-slot4'), preceeds)),
-                         [('verb-slot3',), ('verb-slot4',)])
-        # two constraints, non-sequential, same value
-        self.assertEqual(s(mfs(('verb-slot4', 'verb-slot5'), preceeds)),
-                         [('verb-slot4', 'verb-slot5',)])
-        # four constraints, two non-seq, same val, other two non seq, same val
-        self.assertEqual(s(mfs(('verb-slot1', 'verb-slot2',
-                                'verb-slot4', 'verb-slot5'), preceeds)),
-                         [('verb-slot1', 'verb-slot2',),
-                          ('verb-slot4', 'verb-slot5',)])
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + extended_con_dis_junctive1)
-        preceeds = morphotactics.create_preceeds_dict(ch)
-        # disjunctive and sequential constrainted, all same value
-        self.assertEqual(s(mfs(('verb-slot4', 'verb-slot5', 'verb-slot6'),
-                               preceeds)),
-                         [('verb-slot4', 'verb-slot5',),
-                          ('verb-slot5', 'verb-slot6',)])
-        ch.load_choices(lextypes + extended_con_dis_junctive2)
-        preceeds = morphotactics.create_preceeds_dict(ch)
-        # disjunctive and sequential constrainted, all same value
-        self.assertEqual(s(mfs(('verb-slot4', 'verb-slot5',
-                                'verb-slot6', 'verb-slot7'), preceeds)),
-                         [('verb-slot4', 'verb-slot5',),
-                          ('verb-slot6', 'verb-slot7',)])
-
-    def test_Morpheme(self):
-        # empty
-        self.assertRaises(TypeError, morphotactics.Morpheme)
-        # name only
-        self.assertRaises(TypeError, morphotactics.Morpheme, 'name')
-        # minimal
-        m = morphotactics.Morpheme('name', 'slot_key', 'supertype')
-        self.assertEqual(m.name, 'name')
-        self.assertEqual(m.supertype, 'supertype')
-        self.assertEqual(m.parents, set())
-        self.assertEqual(m.orthography, '')
-        self.assertEqual(m.features, {})
-        # orth
-        m = morphotactics.Morpheme('name', 'slot_key', 'supertype', 'orth')
-        self.assertEqual(m.orthography, 'orth')
-
-    def test_create_morpheme(self):
-        cm = morphotactics.create_morpheme
-        Slot = morphotactics.Slot
-        # no-orth noun
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + simple_no_orth)
-        s = Slot(ch['noun-slot1_name'], 'noun-slot1')
-        m = cm(ch['noun-slot1_morph1'], s.slot_key, ch)
-        self.assertEqual(m.name, 'singular')
-        self.assertEqual(m.parents, set(['num-lex-rule', 'const-lex-rule']))
-        self.assertEqual(m.orthography, '')
-        self.assertEqual(m.features, {'number': {'value': 'sg', 'head': None}})
-        # orth noun
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + simple_with_orth)
-        s = Slot(ch['noun-slot1_name'], 'noun-slot1')
-        m = cm(ch['noun-slot1_morph1'], s.slot_key, ch)
-        self.assertEqual(m.name, 'singular')
-        self.assertEqual(m.parents, set(['num-lex-rule', 'infl-lex-rule']))
-        self.assertEqual(m.orthography, 'g')
-        self.assertEqual(m.features, {'number': {'value': 'sg', 'head': None}})
-        # verb
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + multiple_basetypes)
-        s = Slot(ch['verb-slot1_name'], 'verb-slot1')
-        m = cm(ch['verb-slot1_morph1'], s.slot_key, ch)
-        self.assertEqual(m.name, '3sg')
-        self.assertEqual(m.parents, set(['person-lex-rule', 'infl-lex-rule']))
-        self.assertEqual(m.orthography, 's')
-        self.assertEqual(m.features, {'person': {'value': '3', 'head': 'subj'},
-                                      'number': {'value': 'sg', 'head': 'subj'}})
-
-    def test_create_lexical_rules(self):
-        clrs = morphotactics.create_lexical_rules
-        # no rules
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes)
-        preceeds = morphotactics.create_preceeds_dict(ch)
-        self.assertEqual(clrs(ch, preceeds), {})
-        # no-orth noun
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + simple_no_orth)
-        preceeds = morphotactics.create_preceeds_dict(ch)
-        lrs = clrs(ch, preceeds)
-        self.assertEqual(len(lrs), 2)
-        self.assertEqual(lrs['noun-slot1'].name, 'num')
-        self.assertEqual(lrs['noun-slot1'].slot_key, 'noun-slot1')
-        self.assertEqual(lrs['noun-slot1'].order, 'after')
-        self.assertEqual(len(lrs['noun-slot1'].morphs), 1)
-        self.assertEqual(lrs['noun-slot1'].morphs[0].name, 'singular')
-        self.assertEqual(lrs['noun-slot1'].morphs[0].features,
-                         {'number': {'value': 'sg', 'head': None}})
-        self.assertEqual(lrs['noun1'].name, 'testnoun-noun')
-        self.assertEqual(lrs['noun1'].slot_key, 'noun1')
-        # multiple basetypes
-
-        # sequential verb slots
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + sequential_verb_slots)
-        preceeds = morphotactics.create_preceeds_dict(ch)
-        lrs = clrs(ch, preceeds)
-        self.assertEqual(len(lrs), 5)
-        self.assertEqual(lrs['verb-slot1'].name, 'person')
-        self.assertEqual(lrs['verb-slot1'].slot_key, 'verb-slot1')
-        self.assertEqual(lrs['verb-slot1'].order, 'after')
-        self.assertEqual(len(lrs['verb-slot1'].morphs), 1)
-        self.assertEqual(lrs['verb-slot1'].morphs[0].name, '3sg')
-        self.assertEqual(len(lrs['verb-slot1'].morphs), 1)
-        self.assertEqual(len(lrs['verb-slot2'].morphs), 2)
-        self.assertEqual(len(lrs['verb-slot3'].morphs), 1)
-
-    def test_create_input_dict(self):
-        cid = morphotactics.create_input_dict
-
-        def prep_lrs(choice_lines):
-            ch = customize.choices.ChoicesFile()
-            ch.load_choices(choice_lines)
-            preceeds = morphotactics.create_preceeds_dict(ch)
-            lrs = morphotactics.create_lexical_rules(ch, preceeds)
-            return lrs, preceeds, ch
-        # single input
-        lrs, preceeds, ch = prep_lrs(lextypes + simple_no_orth)
-        self.assertEqual(cid(lrs, preceeds), {('noun1',): set(['noun-slot1'])})
-        # two slots one input
-        lrs, preceeds, ch = prep_lrs(lextypes + competing_slots)
-        self.assertEqual(cid(lrs, preceeds),
-                         {('noun1',): set(['noun-slot1', 'noun-slot2'])})
-        # one slot two inputs
-        lrs, preceeds, ch = prep_lrs(lextypes + multiple_basetypes)
-        self.assertEqual(cid(lrs, preceeds),
-                         {('verb1', 'verb2'): set(['verb-slot1'])})
-        # more complicated things are not yet handled, but should work ok
-        # because of flags. For example, A>B>C>D, A requires B and C, then
-        # D's inputs should just be C, even though B doesn't require C
-        # extended con-dis-junctive
-        #lrs, preceeds, ch = prep_lrs(lextypes + extended_con_dis_junctive2)
-        # self.assertEqual(cid(lrs, preceeds),
-        #                 {('verb1',):set(['verb-slot1','verb-slot2']),
-        #                  ('verb-slot1','verb-slot2'):set(['verb-slot3']),
-        #                  ('verb-slot3',):set(['verb-slot4','verb-slot5']),
-        #                  ('verb-slot4',):set(['verb-slot6']),
-        #                  ('verb-slot5',):set(['verb-slot7'])})
-
-    def test_customize_lexical_rules(self):
-        clrs = morphotactics.customize_lexical_rules
-        # no rules
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes)
-        self.assertEqual(clrs(ch), {})
-        # no-orth noun
-        ch = customize.choices.ChoicesFile()
-        ch.load_choices(lextypes + simple_no_orth)
-        lrs = clrs(ch)
-        self.assertEqual(len(lrs), 2)
-        self.assertEqual(lrs['noun-slot1'].name, 'num')
-        self.assertEqual(lrs['noun-slot1'].slot_key, 'noun-slot1')
-        self.assertEqual(lrs['noun-slot1'].order, 'after')
-        # extended con-dis-junctive
-        #ch = customize.choices.ChoicesFile()
-        #ch.load_choices(lextypes + extended_con_dis_junctive2)
-        #lrs = clrs(ch)
+    # def test_create_preceeds_dict(self):
+    #     # no slots
+    #     choices = customize.choices.ChoicesFile()
+    #     choices.load_choices(lextypes)
+    #     self.assertEqual(morphotactics.create_preceeds_dict(choices), {})
+    #     # single slot
+    #     choices = customize.choices.ChoicesFile()
+    #     choices.load_choices(lextypes + simple_no_orth)
+    #     self.assertEqual(morphotactics.create_preceeds_dict(choices),
+    #                      {'noun-slot1': set(['noun1'])})
+    #     # two morphemes (no different)
+    #     choices = customize.choices.ChoicesFile()
+    #     choices.load_choices(lextypes + two_morphemes)
+    #     self.assertEqual(morphotactics.create_preceeds_dict(choices),
+    #                      {'noun-slot1': set(['noun1'])})
+    #     # competing slots
+    #     choices = customize.choices.ChoicesFile()
+    #     choices.load_choices(lextypes + competing_slots)
+    #     self.assertEqual(morphotactics.create_preceeds_dict(choices),
+    #                      {'noun-slot1': set(['noun1']),
+    #                       'noun-slot2': set(['noun1'])})
+    #     # sequential slots
+    #     choices = customize.choices.ChoicesFile()
+    #     choices.load_choices(lextypes + sequential_slots)
+    #     self.assertEqual(morphotactics.create_preceeds_dict(choices),
+    #                      {'noun-slot1': set(['noun1']),
+    #                       'noun-slot2': set(['noun-slot1', 'noun1'])})
+    #     # multiple basetypes, multiple inputs
+    #     choices = customize.choices.ChoicesFile()
+    #     choices.load_choices(lextypes + sequential_verb_slots)
+    #     self.assertEqual(morphotactics.create_preceeds_dict(choices),
+    #                      {'verb-slot1': set(['verb1', 'verb2']),
+    #                       'verb-slot2': set(['verb-slot1', 'verb1', 'verb2']),
+    #                       'verb-slot3': set(['verb-slot1', 'verb-slot2',
+    #                                          'verb1', 'verb2'])})
+    # 
+    # # def test_disjunctive_typename(self):
+    # #  # for brevity
+    # #  dtname = morphotactics.disjunctive_typename
+    # #  ch = customize.choices.ChoicesFile()
+    # #  ch['a1_name'] = 'a'
+    # #  ch['b1_name'] = 'b'
+    # #  ch['c1_name'] = 'c'
+    # 
+    # #  self.assertEqual(dtname([], ch), '')
+    # #  self.assertEqual(dtname(sorted(['a1']), ch), 'a')
+    # #  self.assertEqual(dtname(sorted(['a1','b1']), ch), 'a-or-b')
+    # #  self.assertEqual(dtname(sorted(['a1','b1','c1']), ch), 'a-or-b-or-c')
+    # 
+    # def test_all_inputs(self):
+    #     # for brevity
+    #     ai = morphotactics.all_inputs
+    #     s = sorted
+    # 
+    #     def prep_lrs(choice_lines):
+    #         ch = customize.choices.ChoicesFile()
+    #         ch.load_choices(choice_lines)
+    #         preceeds = morphotactics.create_preceeds_dict(ch)
+    #         lrs = morphotactics.create_lexical_rules(ch, preceeds)
+    #         return lrs, preceeds, ch
+    #     # no inputs
+    #     lrs, preceeds, ch = prep_lrs(lextypes)
+    #     self.assertEqual(ai('noun1', lrs, preceeds), [])
+    #     self.assertEqual(ai('NOSUCH', lrs, preceeds), [])
+    #     # one input
+    #     lrs, preceeds, ch = prep_lrs(lextypes + simple_no_orth)
+    #     self.assertEqual(ai('noun1', lrs, preceeds), [])
+    #     self.assertEqual(ai('noun-slot1', lrs, preceeds), ['noun1'])
+    #     # multiple inputs
+    #     lrs, preceeds, ch = prep_lrs(lextypes + multiple_basetypes)
+    #     self.assertEqual(s(ai('verb-slot1', lrs, preceeds)),
+    #                      ['verb1', 'verb2'])
+    #     # multiple slots
+    #     lrs, preceeds, ch = prep_lrs(lextypes + competing_slots)
+    #     self.assertEqual(ai('noun-slot1', lrs, preceeds), ['noun1'])
+    #     self.assertEqual(ai('noun-slot2', lrs, preceeds), ['noun1'])
+    #     # sequential
+    #     lrs, preceeds, ch = prep_lrs(lextypes + sequential_verb_slots)
+    #     self.assertEqual(s(ai('verb-slot1', lrs, preceeds)),
+    #                      ['verb1', 'verb2'])
+    #     self.assertEqual(s(ai('verb-slot2', lrs, preceeds)), s(['verb1', 'verb2',
+    #                                                             'verb-slot1']))
+    # 
+    # def test_sequential(self):
+    #     # for brevity
+    #     seq = morphotactics.sequential
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + con_dis_junctive)
+    #     preceeds = morphotactics.create_preceeds_dict(ch)
+    #     self.assertEqual(seq('verb-slot1', 'verb-slot2', preceeds), False)
+    #     self.assertEqual(seq('verb-slot2', 'verb-slot1', preceeds), False)
+    #     self.assertEqual(seq('verb-slot1', 'verb-slot3', preceeds), True)
+    #     self.assertEqual(seq('verb-slot3', 'verb-slot1', preceeds), True)
+    #     self.assertEqual(seq('verb-slot2', 'verb-slot3', preceeds), True)
+    #     self.assertEqual(seq('verb-slot3', 'verb-slot2', preceeds), True)
+    #     self.assertEqual(seq('verb-slot3', 'verb-slot4', preceeds), True)
+    #     self.assertEqual(seq('verb-slot4', 'verb-slot3', preceeds), True)
+    #     self.assertEqual(seq('verb-slot1', 'verb-slot4', preceeds), True)
+    #     self.assertEqual(seq('verb-slot4', 'verb-slot1', preceeds), True)
+    #     self.assertEqual(seq('verb-slot4', 'verb-slot5', preceeds), False)
+    #     self.assertEqual(seq('verb-slot5', 'verb-slot4', preceeds), False)
+    #     self.assertEqual(seq('verb-slot1', 'verb-slot1', preceeds), False)
+    #     self.assertEqual(seq('verb-slot42', 'verb-slot99', preceeds), False)
+    # 
+    # def test_ordered_constraints(self):
+    #     # for brevity
+    #     oc = morphotactics.ordered_constraints
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + extended_con_dis_junctive2)
+    #     preceeds = morphotactics.create_preceeds_dict(ch)
+    #     # one slot
+    #     self.assertEqual(oc(['verb-slot1'], preceeds), ['verb-slot1'])
+    #     # nonsequential, ordered by name
+    #     self.assertEqual(oc(['verb-slot1', 'verb-slot2'], preceeds),
+    #                      ['verb-slot1', 'verb-slot2'])
+    #     # nonsequential, not ordered by name
+    #     self.assertEqual(oc(['verb-slot2', 'verb-slot1'], preceeds),
+    #                      ['verb-slot1', 'verb-slot2'])
+    #     # sequential
+    #     self.assertEqual(oc(['verb-slot4', 'verb-slot1'], preceeds),
+    #                      ['verb-slot1', 'verb-slot4'])
+    #     # sequential and nonsequential
+    #     self.assertEqual(oc(['verb-slot7', 'verb-slot5', 'verb-slot4', 'verb-slot6'],
+    #                         preceeds),
+    #                      ['verb-slot4', 'verb-slot5', 'verb-slot6', 'verb-slot7'])
+    # 
+    # def test_minimal_flag_set(self):
+    #     # for brevity
+    #     s = sorted
+    #     mfs = morphotactics.minimal_flag_set
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + con_dis_junctive)
+    #     preceeds = morphotactics.create_preceeds_dict(ch)
+    #     # no constraints
+    #     self.assertEqual(mfs({}, preceeds), [])
+    #     # single constraint (a or b forces c)
+    #     self.assertEqual(mfs(('verb-slot3',), preceeds), [('verb-slot3',)])
+    #     # two constraints, sequential
+    #     self.assertEqual(s(mfs(('verb-slot3', 'verb-slot4'), preceeds)),
+    #                      [('verb-slot3',), ('verb-slot4',)])
+    #     # two constraints, non-sequential, same value
+    #     self.assertEqual(s(mfs(('verb-slot4', 'verb-slot5'), preceeds)),
+    #                      [('verb-slot4', 'verb-slot5',)])
+    #     # four constraints, two non-seq, same val, other two non seq, same val
+    #     self.assertEqual(s(mfs(('verb-slot1', 'verb-slot2',
+    #                             'verb-slot4', 'verb-slot5'), preceeds)),
+    #                      [('verb-slot1', 'verb-slot2',),
+    #                       ('verb-slot4', 'verb-slot5',)])
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + extended_con_dis_junctive1)
+    #     preceeds = morphotactics.create_preceeds_dict(ch)
+    #     # disjunctive and sequential constrainted, all same value
+    #     self.assertEqual(s(mfs(('verb-slot4', 'verb-slot5', 'verb-slot6'),
+    #                            preceeds)),
+    #                      [('verb-slot4', 'verb-slot5',),
+    #                       ('verb-slot5', 'verb-slot6',)])
+    #     ch.load_choices(lextypes + extended_con_dis_junctive2)
+    #     preceeds = morphotactics.create_preceeds_dict(ch)
+    #     # disjunctive and sequential constrainted, all same value
+    #     self.assertEqual(s(mfs(('verb-slot4', 'verb-slot5',
+    #                             'verb-slot6', 'verb-slot7'), preceeds)),
+    #                      [('verb-slot4', 'verb-slot5',),
+    #                       ('verb-slot6', 'verb-slot7',)])
+    # 
+    # def test_Morpheme(self):
+    #     # empty
+    #     self.assertRaises(TypeError, morphotactics.Morpheme)
+    #     # name only
+    #     self.assertRaises(TypeError, morphotactics.Morpheme, 'name')
+    #     # minimal
+    #     m = morphotactics.Morpheme('name', 'slot_key', 'supertype')
+    #     self.assertEqual(m.name, 'name')
+    #     self.assertEqual(m.supertype, 'supertype')
+    #     self.assertEqual(m.parents, set())
+    #     self.assertEqual(m.orthography, '')
+    #     self.assertEqual(m.features, {})
+    #     # orth
+    #     m = morphotactics.Morpheme('name', 'slot_key', 'supertype', 'orth')
+    #     self.assertEqual(m.orthography, 'orth')
+    # 
+    # def test_create_morpheme(self):
+    #     cm = morphotactics.create_morpheme
+    #     Slot = morphotactics.Slot
+    #     # no-orth noun
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + simple_no_orth)
+    #     s = Slot(ch['noun-slot1_name'], 'noun-slot1')
+    #     m = cm(ch['noun-slot1_morph1'], s.slot_key, ch)
+    #     self.assertEqual(m.name, 'singular')
+    #     self.assertEqual(m.parents, set(['num-lex-rule', 'const-lex-rule']))
+    #     self.assertEqual(m.orthography, '')
+    #     self.assertEqual(m.features, {'number': {'value': 'sg', 'head': None}})
+    #     # orth noun
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + simple_with_orth)
+    #     s = Slot(ch['noun-slot1_name'], 'noun-slot1')
+    #     m = cm(ch['noun-slot1_morph1'], s.slot_key, ch)
+    #     self.assertEqual(m.name, 'singular')
+    #     self.assertEqual(m.parents, set(['num-lex-rule', 'infl-lex-rule']))
+    #     self.assertEqual(m.orthography, 'g')
+    #     self.assertEqual(m.features, {'number': {'value': 'sg', 'head': None}})
+    #     # verb
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + multiple_basetypes)
+    #     s = Slot(ch['verb-slot1_name'], 'verb-slot1')
+    #     m = cm(ch['verb-slot1_morph1'], s.slot_key, ch)
+    #     self.assertEqual(m.name, '3sg')
+    #     self.assertEqual(m.parents, set(['person-lex-rule', 'infl-lex-rule']))
+    #     self.assertEqual(m.orthography, 's')
+    #     self.assertEqual(m.features, {'person': {'value': '3', 'head': 'subj'},
+    #                                   'number': {'value': 'sg', 'head': 'subj'}})
+    # 
+    # def test_create_lexical_rules(self):
+    #     clrs = morphotactics.create_lexical_rules
+    #     # no rules
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes)
+    #     preceeds = morphotactics.create_preceeds_dict(ch)
+    #     self.assertEqual(clrs(ch, preceeds), {})
+    #     # no-orth noun
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + simple_no_orth)
+    #     preceeds = morphotactics.create_preceeds_dict(ch)
+    #     lrs = clrs(ch, preceeds)
+    #     self.assertEqual(len(lrs), 2)
+    #     self.assertEqual(lrs['noun-slot1'].name, 'num')
+    #     self.assertEqual(lrs['noun-slot1'].slot_key, 'noun-slot1')
+    #     self.assertEqual(lrs['noun-slot1'].order, 'after')
+    #     self.assertEqual(len(lrs['noun-slot1'].morphs), 1)
+    #     self.assertEqual(lrs['noun-slot1'].morphs[0].name, 'singular')
+    #     self.assertEqual(lrs['noun-slot1'].morphs[0].features,
+    #                      {'number': {'value': 'sg', 'head': None}})
+    #     self.assertEqual(lrs['noun1'].name, 'testnoun-noun')
+    #     self.assertEqual(lrs['noun1'].slot_key, 'noun1')
+    #     # multiple basetypes
+    # 
+    #     # sequential verb slots
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + sequential_verb_slots)
+    #     preceeds = morphotactics.create_preceeds_dict(ch)
+    #     lrs = clrs(ch, preceeds)
+    #     self.assertEqual(len(lrs), 5)
+    #     self.assertEqual(lrs['verb-slot1'].name, 'person')
+    #     self.assertEqual(lrs['verb-slot1'].slot_key, 'verb-slot1')
+    #     self.assertEqual(lrs['verb-slot1'].order, 'after')
+    #     self.assertEqual(len(lrs['verb-slot1'].morphs), 1)
+    #     self.assertEqual(lrs['verb-slot1'].morphs[0].name, '3sg')
+    #     self.assertEqual(len(lrs['verb-slot1'].morphs), 1)
+    #     self.assertEqual(len(lrs['verb-slot2'].morphs), 2)
+    #     self.assertEqual(len(lrs['verb-slot3'].morphs), 1)
+    # 
+    # def test_create_input_dict(self):
+    #     cid = morphotactics.create_input_dict
+    # 
+    #     def prep_lrs(choice_lines):
+    #         ch = customize.choices.ChoicesFile()
+    #         ch.load_choices(choice_lines)
+    #         preceeds = morphotactics.create_preceeds_dict(ch)
+    #         lrs = morphotactics.create_lexical_rules(ch, preceeds)
+    #         return lrs, preceeds, ch
+    #     # single input
+    #     lrs, preceeds, ch = prep_lrs(lextypes + simple_no_orth)
+    #     self.assertEqual(cid(lrs, preceeds), {('noun1',): set(['noun-slot1'])})
+    #     # two slots one input
+    #     lrs, preceeds, ch = prep_lrs(lextypes + competing_slots)
+    #     self.assertEqual(cid(lrs, preceeds),
+    #                      {('noun1',): set(['noun-slot1', 'noun-slot2'])})
+    #     # one slot two inputs
+    #     lrs, preceeds, ch = prep_lrs(lextypes + multiple_basetypes)
+    #     self.assertEqual(cid(lrs, preceeds),
+    #                      {('verb1', 'verb2'): set(['verb-slot1'])})
+    #     # more complicated things are not yet handled, but should work ok
+    #     # because of flags. For example, A>B>C>D, A requires B and C, then
+    #     # D's inputs should just be C, even though B doesn't require C
+    #     # extended con-dis-junctive
+    #     #lrs, preceeds, ch = prep_lrs(lextypes + extended_con_dis_junctive2)
+    #     # self.assertEqual(cid(lrs, preceeds),
+    #     #                 {('verb1',):set(['verb-slot1','verb-slot2']),
+    #     #                  ('verb-slot1','verb-slot2'):set(['verb-slot3']),
+    #     #                  ('verb-slot3',):set(['verb-slot4','verb-slot5']),
+    #     #                  ('verb-slot4',):set(['verb-slot6']),
+    #     #                  ('verb-slot5',):set(['verb-slot7'])})
+    # 
+    # def test_customize_lexical_rules(self):
+    #     clrs = morphotactics.customize_lexical_rules
+    #     # no rules
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes)
+    #     self.assertEqual(clrs(ch), {})
+    #     # no-orth noun
+    #     ch = customize.choices.ChoicesFile()
+    #     ch.load_choices(lextypes + simple_no_orth)
+    #     lrs = clrs(ch)
+    #     self.assertEqual(len(lrs), 2)
+    #     self.assertEqual(lrs['noun-slot1'].name, 'num')
+    #     self.assertEqual(lrs['noun-slot1'].slot_key, 'noun-slot1')
+    #     self.assertEqual(lrs['noun-slot1'].order, 'after')
+    #     # extended con-dis-junctive
+    #     #ch = customize.choices.ChoicesFile()
+    #     #ch.load_choices(lextypes + extended_con_dis_junctive2)
+    #     #lrs = clrs(ch)
 
 
 ##############################################################################
@@ -454,3 +460,6 @@ extended_con_dis_junctive2 = extended_con_dis_junctive1 + \
                                verb-slot7_order=after
                                  verb-slot7_input1_type=verb-slot5
                                  verb_slot7_morph1_name=gm'''.splitlines()
+                                 
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/validate_test.py
+++ b/tests/unit/validate_test.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+'''
+Run these tests with `python -m tests.unit.validate_test` from the matrix directory.
+'''
 
 import unittest
 from gmcs.choices import ChoicesFile
@@ -290,7 +293,11 @@ class TestValidate(unittest.TestCase):
         # missing answers about particles
         c = ChoicesFile()
         c['q-part'] = 'on'
-        self.assertErrors(c, ['q-part-order', 'q-part-orth'])
+        # missing order and no specified particles
+        self.assertErrors(c, ['q-part-order', 'q-particle'])
+        # missing orth of specified particle
+        c['q-particle1_main'] = 'on' 
+        self.assertErrors(c, ['q-particle'])
 
         # missing or incompatible answers about inversion
         c = ChoicesFile()
@@ -371,6 +378,10 @@ class TestValidate(unittest.TestCase):
         c['has-dets'] = 'no'
         self.assertErrors(c, ['has-dets', 'noun1_det'])
 
+        # question pronoun, but no question constituent question selections
+        c['noun1_inter'] = 'on'
+        self.assertWarnings(c, ['noun1_inter'])
+        
         # Verbs
         c = ChoicesFile()
         c['verb1_dummy'] = 'dummy'
@@ -400,11 +411,6 @@ class TestValidate(unittest.TestCase):
         c['aux1_sem'] = ''
         c['aux1_stem1_pred'] = 'dummy'
         self.assertError(c, 'aux1_sem')
-
-        # Adpositions
-        c = ChoicesFile()
-        c['adp1_dummy'] = 'dummy'
-        self.assertWarning(c, 'adp1_feat1_name')
 
         # Adpositions
         c = ChoicesFile()
@@ -443,7 +449,7 @@ class TestValidate(unittest.TestCase):
                 #  self.assertErrors(c, [pcprefix + '-pc1_lrt1_feat1_name',
                 #                        pcprefix + '-pc1_lrt1_feat1_value'])
                 #  if pcprefix == 'verb':
-                #    self.assertError(c, pcprefix + '-pc1_lrt1_feat1_head')
+                #    self.assertError(c, pcprefix + '-pc1_lrt1_feat1_head')             
 
     def test_features(self):
         # try a bad feature and value everywhere
@@ -455,6 +461,24 @@ class TestValidate(unittest.TestCase):
             c[p + '1_feat1_name'] = 'dummy'
             c[p + '1_feat1_value'] = 'dummy'
             self.assertErrors(c, [p + '1_feat1_name', p + '1_feat1_value'])
+            
+    
+        # test features whose categories do not match lrt feature head
+        for lt in ['verb-pc1_lrt' , 'adj-pc1_lrt']: 
+            c = ChoicesFile()
+            feature_name = 'feat1'
+            for head in ['subj', 'obj', 'noun']:
+                c[lt + '1_feat1_name'] = feature_name
+                c['feature1_name'] = feature_name
+                c['feature1_cat'] = 'verb'
+                c[lt + '1_feat1_head'] = head
+                self.assertError(c, lt + '1_feat1_head') 
+            for head in ['verb']:
+                c[lt + '1_feat1_name'] = feature_name
+                c['feature1_name'] = feature_name
+                c['feature1_cat'] = 'noun'
+                c[lt + '1_feat1_head'] = head
+                self.assertError(c, lt + '1_feat1_head')   
 
     def test_argopt(self):
         c = ChoicesFile()
@@ -464,3 +488,6 @@ class TestValidate(unittest.TestCase):
         self.assertErrors(c, ['subj-mark-drop', 'subj-mark-no-drop',
                               'obj-mark-drop', 'obj-mark-no-drop',
                               'context1_feat1_head'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#698 
#624 

Commented out all of morphotactics_test.py since it's extremely outdated and needs major update.


Added validation on wh-pronouns when there is no data selected on the wh-questions subpage
![Screen Shot 2024-09-19 at 7 21 35 PM](https://github.com/user-attachments/assets/5e4fa199-3947-42a5-b533-4bee9b43ed9d)
![Screen Shot 2024-09-19 at 7 21 39 PM](https://github.com/user-attachments/assets/6245f15a-9e1b-459b-8d21-93972c6ed365)



Added valdation for verb and adj pc lrts where the head of an lrt feature is not allowed with the category of the feature
VPs:
![Screen Shot 2024-09-19 at 6 35 03 PM](https://github.com/user-attachments/assets/dd931ac2-a982-4c32-a983-5231285fd082)
![Screen Shot 2024-09-19 at 6 34 52 PM](https://github.com/user-attachments/assets/5afb11aa-9621-44ab-8231-a46aeca7a4cc)
NPs:
![Screen Shot 2024-09-19 at 6 35 10 PM](https://github.com/user-attachments/assets/31a5d87e-6331-4340-b63a-4262069e1419)
![Screen Shot 2024-09-19 at 6 35 17 PM](https://github.com/user-attachments/assets/ab0b2a70-6eec-45c5-b818-656f3268b7ab)

