### PR TITLE
Changing Select to Radio so that direct-inverse will clear

### DIFF
--- a/web/matrixdef
+++ b/web/matrixdef
@@ -790,9 +790,11 @@ BeginIter scale{i} "a Scale Entry" 1
 
 EndIter scale
 
-Select scale-equal "Direction when equal" "<p>When the agent and patient have the same scale value, the main verb is " "<br>(The other form may be something like a reflexive.  If you select \"some other form\", the resulting grammar will not parse sentences where the agent and patient are equally ranked.  You will need to edit the starter grammar manually to add the other form.)</p>"
-. direct "Direct" "direct"
-. other "Some other form" "some other form"
+Radio scale-equal "Direction when equal" "<p>When the agent and patient have the same scale value, the main verb is:</p>" ""
+. direct "direct" "" "direct"
+. other "other" "" "Some other form"
+
+Label "<p>The other form may be something like a reflexive.  If you select some other form, the resulting grammar will not parse sentences where the agent and patient are equally ranked.  You will need to edit the starter grammar manually to add the other form.</p>"
 
 
 Section tense-aspect-mood "Tense, Aspect and Mood"


### PR DESCRIPTION
#432 

The issue was only a UI oddity, not an issue with the choices or generation. The direct is autopopulated in the select dropdown so when the subpage was cleared, it would still be populated but would not be included in the choices. I updated this to be a radio so that it was obvious the choice was cleared. I chose "some other form", saved, downloaded choices and saw the choice, then cleared web page and uploaded the choices file and saw the choice populated. 

![Screen Shot 2024-10-10 at 5 24 56 PM](https://github.com/user-attachments/assets/c2e81cf2-8ea7-4de9-87c1-8c9cd47c51a4)
![Screen Shot 2024-10-10 at 5 25 02 PM](https://github.com/user-attachments/assets/55d570d2-6f87-40d9-b6ec-6e4d46b84185)
![Screen Shot 2024-10-10 at 5 25 09 PM](https://github.com/user-attachments/assets/a0248ad1-e943-43d1-aad4-5b5aca0cda2b)
