### PR TITLE
adding validation and tests or negative adverb namespace issue

### DIFF
--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
 from gmcs.linglib import case
-#from gmcs.linglib import lexical_items
 from gmcs.utils import get_name
 from gmcs import constants
 from gmcs.constants import MTRX_FRONT
@@ -10,8 +9,6 @@ from gmcs.linglib.lexbase import LexicalType, PositionClass
 from gmcs.linglib.lexbase import ALL_LEX_TYPES
 from gmcs.linglib.lexbase import LEXICAL_CATEGORIES
 from gmcs.linglib.lexbase import LEXICAL_SUPERTYPES
-
-
 
 def lexical_type_hierarchy(choices, lexical_supertype):
     if lexical_supertype not in LEXICAL_CATEGORIES:
@@ -1017,7 +1014,7 @@ def validate_lexicon(ch, vr):
     for adp in ch.get('adp'):
         #The below message is no longer needed, since adpositions with no defined
         #adpositions are given automatic FORM values
-        #if 'feat' not in adp:
+        # if 'feat' not in adp:
         #    mess = 'You should specify a value for at least one feature (e.g., CASE).'
         #    vr.warn(adp.full_key + '_feat1_name', mess)
         # EKN 2018-02-05 Warn people not to try to use lexicon page for possessive words
@@ -1071,6 +1068,13 @@ def validate_lexicon(ch, vr):
                 if "_a_rel" in stem['pred']:
                     mess = 'You have indicated this is a question adverb. Please update predicate to be a noun relation.'
                     vr.warn(stem.full_key+'_pred', mess)
+        
+        # check that stem does not match any existing negative adverb
+        neg_adv = ch.get('neg-adv-orth')
+        stems = adv['stem']
+        for s in stems:        
+            if s['orth'] == neg_adv:
+                vr.err(s.full_key+'_orth', 'You have used this spelling for an adverb on the sentential negation page. Please choose a unique spelling.')
 
     # Features on all lexical types
     # TJT 2014-09-02: Adding adj and cop

--- a/gmcs/linglib/negation.py
+++ b/gmcs/linglib/negation.py
@@ -1019,7 +1019,7 @@ def validate(ch, vr):
         #         mess = 'You have not indicated on the word order page that your language has auxiliaries.'
         #         vr.err('neg-infl-type', mess)
 
-    # If adverb is indicated, must lexical entry, what it modifies, and
+    # If adverb is indicated, must specify lexical entry, what it modifies, and
     # ind/selected modifier -- now only applicable under single negation
     # bipartite negs need to validate this for themeselves
     if (ch.get('adv-neg') == 'on') and (ch.get('neg-exp') == '1'):
@@ -1039,6 +1039,15 @@ def validate(ch, vr):
             mess = 'If sentential negation is expressed through an adverb, ' + \
                    'you must specify the form of the adverb.'
             vr.err('neg-adv-orth', mess)
+            
+        # check that stem does not match any existing adverbs in lexicon
+        neg_adv = ch.get('neg-adv-orth')
+        for adv in ch.get('adv'):
+            stems = adv['stem']
+            for s in stems:
+                if s['orth'] == neg_adv:
+                    vr.err('neg-adv-orth', 'You have used this spelling for an adverb on the lexicon page. Please choose a unique spelling.')
+
 
     if ch.get('comp-neg') == 'on':
         if ch.get('comp-neg-head') == 'aux' and ch.get('has-aux') != 'yes':

--- a/tests/unit/validate_test.py
+++ b/tests/unit/validate_test.py
@@ -7,6 +7,7 @@ import unittest
 from gmcs.choices import ChoicesFile, ChoiceList, ChoiceDict
 from gmcs.validate import validate
 
+import sys
 
 class TestValidate(unittest.TestCase):
 
@@ -266,6 +267,11 @@ class TestValidate(unittest.TestCase):
         c['comp-neg'] = 'on'
         c['comp-neg-head'] = 'aux'
         self.assertError(c, 'comp-neg-head')
+    
+        # negation adverb has same spelling as one already defined 
+        c['neg-adv-orth'] = 'test'
+        c['adv1_stem1_orth'] = 'test'
+        self.assertError(c, 'neg-adv-orth')
 
     def test_coordination(self):
         # missing answers
@@ -423,7 +429,7 @@ class TestValidate(unittest.TestCase):
                 c[st] = 'on'
                 c[t + '-subtype1_name'] = 'dummy'
                 self.assertError(c, t + '-subtype1_name')
-                
+
         # added a hierarchy element but didn't answer yes to tense-definition
         c = ChoicesFile()
         c['past'] = 'on'
@@ -519,14 +525,19 @@ class TestValidate(unittest.TestCase):
 
         # Adpositions
         c = ChoicesFile()
-        c['adp1_dummy'] = 'dummy'
-        self.assertWarning(c, 'adp1_feat1_name')
+        c['adp1_feat1_name'] = 'poss-strat'
+        self.assertError(c, 'adp1_feat1_name')
         
         # Adverbs 
         c = ChoicesFile()
         c['adv1_stem1_pred'] = '_pred_a_rel'
         c['adv1_inter'] = 'on'
         self.assertWarning(c, 'adv1_stem1_pred')
+
+        c = ChoicesFile()
+        c['neg-adv-orth'] = 'test'
+        c['adv1_stem1_orth'] = 'test'
+        self.assertError(c, 'adv1_stem1_orth')
 
         # Features
         for lt in ['noun', 'verb', 'aux', 'det', 'adp']:


### PR DESCRIPTION
#363 

Testing this before making changes... negative adverb named same as lexicon adverb results in 

testneg := testneg-adverb-lex & neg-adv-lex &
  [ STEM < "testneg" >,
    SYNSEM.LKEYS.KEYREL.PRED "_testneg_a_rel" & "neg_rel" ].

whereas two differently named ones results in

testneg2 := testneg2-adverb-lex &
  [ STEM < "testneg2" >,
    SYNSEM.LKEYS.KEYREL.PRED "_testneg2_a_rel" ].

testneg := neg-adv-lex &
  [ STEM < "testneg" >,
    SYNSEM.LKEYS.KEYREL.PRED "neg_rel" ].

in the lexicon.

Now, there is validation on both pages that prevents this.
![Screen Shot 2024-10-16 at 4 47 02 PM](https://github.com/user-attachments/assets/6d83cf76-ad19-4cd0-b8fe-b67c4b08e87e)

![Screen Shot 2024-10-16 at 4 47 29 PM](https://github.com/user-attachments/assets/1f358e9c-8187-4318-b0b7-4849c9616664)