### PR TITLE
adding logging and proper exception raising

### DIFF
--- a/gmcs/choices.py
+++ b/gmcs/choices.py
@@ -410,9 +410,9 @@ class ChoicesFile:
                 self.load_choices(lines)
                 if type(choices_file) == str:
                     f.close()
-            except IOError:
-                print('Error loading choices from %s' % choices_file)
-                raise
+            except IOError as io:
+                message = 'Error loading choices from ' + choices_file + ": "
+                raise IOError(message + repr(io))
 
     def __str__(self):
         return str(self.choices)
@@ -467,15 +467,15 @@ class ChoicesFile:
                 if key.strip() in ('section', 'version'):
                     continue
                 choices[key.strip()] = value
-            except ValueError:
-                print('Error parsing choices on line: ', line)
-                raise
-            except AttributeError:
-                print('Error parsing choices on line: ', line)
-                raise
-            except ChoicesFileParseError:
-                print('Error parsing choices on line: ', line)
-                raise
+            except ValueError as v:
+                message = 'Error parsing choices on line: ' + line + ": "
+                raise ValueError(message + repr(v))
+            except AttributeError as a:
+                message = 'Error parsing choices on line :' + line + ": "
+                raise AttributeError(message + repr(a))
+            except ChoicesFileParseError as c:
+                message = 'Error parsing choices on line: ' + line + ": "
+                raise ChoicesFileParseError(message + repr(c))
         return choices
 
     ############################################################################
@@ -594,9 +594,9 @@ class ChoicesFile:
                 # add back to the lines
                 if key is not None:
                     new_lines += ['='.join([key, value])]
-            except ValueError:
-                print('Error converting choices on line: ', line)
-                raise
+            except ValueError as v:
+                message = 'Error converting choices on line: ' + line + ": "
+                raise ValueError(message + repr(v))
             except ChoicesFileParseError:
                 raise ChoicesFileParseError(
                     'Variable is multiply defined: %s' % key)

--- a/gmcs/choices.py
+++ b/gmcs/choices.py
@@ -411,7 +411,8 @@ class ChoicesFile:
                 if type(choices_file) == str:
                     f.close()
             except IOError:
-                pass  # TODO: we should really be logging these
+                print('Error loading choices from %s' % choices_file)
+                raise
 
     def __str__(self):
         return str(self.choices)
@@ -459,17 +460,22 @@ class ChoicesFile:
         """
         choices = ChoiceDict()
         for line in [l.strip() for l in choice_lines if l.strip() != '']:
+            if line == "":
+                continue
             try:
                 (key, value) = line.split('=', 1)
                 if key.strip() in ('section', 'version'):
                     continue
                 choices[key.strip()] = value
             except ValueError:
-                pass  # TODO: log this!
+                print('Error parsing choices on line: ', line)
+                raise
             except AttributeError:
-                pass  # TODO: log this!
+                print('Error parsing choices on line: ', line)
+                raise
             except ChoicesFileParseError:
-                pass  # TODO: log this!
+                print('Error parsing choices on line: ', line)
+                raise
         return choices
 
     ############################################################################
@@ -575,6 +581,8 @@ class ChoicesFile:
         """
         new_lines = []
         for line in choice_lines:
+            if line == "":
+                continue
             try:
                 (key, value) = line.split('=', 1)
                 if key in ('section', 'version'):
@@ -587,7 +595,8 @@ class ChoicesFile:
                 if key is not None:
                     new_lines += ['='.join([key, value])]
             except ValueError:
-                pass  # TODO: log this!
+                print('Error converting choices on line: ', line)
+                raise
             except ChoicesFileParseError:
                 raise ChoicesFileParseError(
                     'Variable is multiply defined: %s' % key)

--- a/tests/regression/choices/adnom-poss-was
+++ b/tests/regression/choices/adnom-poss-was
@@ -1,4 +1,4 @@
-k
+
 version=32
 
 section=general

--- a/tests/regression/choices/clausalmods-subord-pairs
+++ b/tests/regression/choices/clausalmods-subord-pairs
@@ -83,5 +83,3 @@ section=gen-options
 
 section=ToolboxLexicon
 
-choices.txt
-Displaying choices.txt.

--- a/tests/unit/choices_test.py
+++ b/tests/unit/choices_test.py
@@ -206,9 +206,8 @@ class TestChoicesFileParsingFunctions(unittest.TestCase):
                          {'abc': [{'def': 'DEF1'}, {'def': 'DEF2'}]})
         self.assertEqual(c.parse_choices(['abc2_def=DEF2', 'abc1_def=DEF1']),
                          {'abc': [{'def': 'DEF1'}, {'def': 'DEF2'}]})
-        # not currently throwing this error, but it should be logged.
-        # self.assertRaises(ChoicesFileParseError,
-        #                  c.parse_choices, ['abc2_def=DEF2', 'abc2_def=DEF1'])
+        # exception raising cannot be tested with assertRaises - string choices 
+        # will not throw Attribute or Value exceptions
 
     def test_full_key(self):
         c = ChoicesFile()


### PR DESCRIPTION
I don't see any case where these exceptions could be thrown because the choices file is treated all as strings, but given that it was written this way, I left them and added logging and exception throwing. I made two changes to the regression tests which I believe were invalid text in their choices files. These caused the new exceptions to be thrown. 