### PR TITLE
warn validation on det preds + suggestion, tests

### DIFF
--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -1010,8 +1010,8 @@ def validate_lexicon(ch, vr):
                 mess = 'You must specify a predicate for each determiner you define.'
                 vr.err(stem.full_key + '_pred', mess)
 
-            if re.search("^_.*_q_rel$", stem.get('pred')) == None:
-                mess = 'Predicate should take the form _*_q_rel.'
+            if re.search("^.*_q_rel$", stem.get('pred')) == None:
+                mess = 'Predicate should take the form *_q_rel.'
                 vr.warn(stem.full_key + '_pred', mess)
 
     # Adpositions

--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -10,6 +10,8 @@ from gmcs.linglib.lexbase import ALL_LEX_TYPES
 from gmcs.linglib.lexbase import LEXICAL_CATEGORIES
 from gmcs.linglib.lexbase import LEXICAL_SUPERTYPES
 
+import re
+
 def lexical_type_hierarchy(choices, lexical_supertype):
     if lexical_supertype not in LEXICAL_CATEGORIES:
         return None
@@ -1007,6 +1009,10 @@ def validate_lexicon(ch, vr):
             if not stem.get('pred'):
                 mess = 'You must specify a predicate for each determiner you define.'
                 vr.err(stem.full_key + '_pred', mess)
+
+            if re.search("^_.*_q_rel$", stem.get('pred')) == None:
+                mess = 'Predicate should take the form _*_q_rel.'
+                vr.warn(stem.full_key + '_pred', mess)
 
     # Adpositions
     for adp in ch.get('adp'):

--- a/tests/unit/validate_test.py
+++ b/tests/unit/validate_test.py
@@ -540,7 +540,7 @@ class TestValidate(unittest.TestCase):
         
         # Determiners
         c = ChoicesFile()
-        c['det1_stem1_pred'] = '_x_q_rel'
+        c['det1_stem1_pred'] = 'x_q_rel'
         self.assertError(c, 'det1_stem1_orth')
         
         c = ChoicesFile()

--- a/tests/unit/validate_test.py
+++ b/tests/unit/validate_test.py
@@ -537,6 +537,19 @@ class TestValidate(unittest.TestCase):
         c['neg-adv-orth'] = 'test'
         c['adv1_stem1_orth'] = 'test'
         self.assertError(c, 'adv1_stem1_orth')
+        
+        # Determiners
+        c = ChoicesFile()
+        c['det1_stem1_pred'] = '_x_q_rel'
+        self.assertError(c, 'det1_stem1_orth')
+        
+        c = ChoicesFile()
+        c['det1_stem1_orth'] = 'test'
+        self.assertError(c, 'det1_stem1_pred')
+        
+        c = ChoicesFile()
+        c['det1_stem1_pred'] = 'test'
+        self.assertWarning(c, 'det1_stem1_pred')
 
         # Features
         for lt in ['noun', 'verb', 'aux', 'det', 'adp']:

--- a/web/matrixdef
+++ b/web/matrixdef
@@ -3174,9 +3174,9 @@ BeginIter det{i} "a Determiner" 1
 
   BeginIter stem{j} "a Stem" 0 1
 
-    Text orth "Determiner {i} spelling" "Spelling: " "" 30 "fill_pred('det{i}_stem{j}', 'q')"
+    Text orth "Determiner {i} spelling" "Spelling: " "" 30
 
-    Text pred "Determiner {i} predicate" " Predicate: " "<br>" 30
+    Text pred "Determiner {i} predicate" " Predicate: " "<br>Predicate suggestion: use _exist_q_rel for existentials and _all_q_rel for universals" 30
 
   EndIter stem
 

--- a/web/matrixdef
+++ b/web/matrixdef
@@ -3176,7 +3176,7 @@ BeginIter det{i} "a Determiner" 1
 
     Text orth "Determiner {i} spelling" "Spelling: " "" 30
 
-    Text pred "Determiner {i} predicate" " Predicate: " "<br>Predicate suggestion: use _exist_q_rel for existentials and _all_q_rel for universals" 30
+    Text pred "Determiner {i} predicate" " Predicate: " "<br>Predicate suggestion: use exist_q_rel for existentials and all_q_rel for universals" 30
 
   EndIter stem
 


### PR DESCRIPTION
#415 Don't autofill det preds, add suggestion, validation and tests

I made this validation a warn since all predicates are technically (as of right now) not validated for form so I wasn't sure whether blocking a user from making a freeform pred was a good idea. 

<img width="682" alt="Screen Shot 2024-10-19 at 3 06 50 PM" src="https://github.com/user-attachments/assets/4553cddc-9e8f-4cce-a86f-043ec3c7f1fc">
<img width="829" alt="Screen Shot 2024-10-19 at 3 06 41 PM" src="https://github.com/user-attachments/assets/61f4d3d7-07d0-4375-a308-0f9ae751067d">
