### PR TITLE
Validating on neg-aux pred

### DIFF
--- a/gmcs/linglib/negation.py
+++ b/gmcs/linglib/negation.py
@@ -989,13 +989,15 @@ def validate(ch, vr):
     if ch.get('neg-aux', default=False):
         has_neg_aux = False
         for aux in ch.get('aux', []):
-            if aux.get('name') == 'neg':
-                has_neg_aux = True
-                break
+            stems = aux.get('stem', [])
+            for s in stems:
+                if s.get('pred') == 'neg_rel':
+                    has_neg_aux = True
+                    break
         if has_neg_aux == False:
             vr.warn('neg-aux',
                     'You\'ve selected neg-aux but there is no corresponding ' +
-                    'type in the lexicon.')
+                    'type in the lexicon with a neg_rel predicate.')
             # ERB 2009-01-23 Commenting out the following because infl-neg is
             # now handled with customize_inflection.  We should eventually give
             # a warning if infl-neg is selected but no lexical rules actually

--- a/tests/unit/validate_test.py
+++ b/tests/unit/validate_test.py
@@ -32,6 +32,20 @@ class TestValidate(unittest.TestCase):
 
     def assertErrors(self, c, errors):
         self.assertErrorsOrWarnings(c, errors, True)
+        
+    def assertNoErrors(self, c, errors):
+        vr = validate(c)
+        if isinstance(errors, str):
+            errors = [errors]
+        for e in errors:
+            self.assertFalse(e in vr.errors)
+
+    def assertNoWarnings(self, c, warnings):
+        vr = validate(c)
+        if isinstance(warnings, str):
+            warnings = [warnings]
+        for w in warnings:
+            self.assertFalse(w in vr.warnings)
 
     # Tests
 
@@ -279,6 +293,15 @@ class TestValidate(unittest.TestCase):
         c['neg-adv-orth'] = 'test'
         c['adv1_stem1_orth'] = 'test'
         self.assertError(c, 'neg-adv-orth')
+        
+        # no negation auxiliary in lexicon with neg_rel predicate
+        c['neg-aux'] = 'on'
+        self.assertWarning(c, 'neg-aux')
+        c['aux1_name'] =  'neg'
+        c['aux1_stem1_pred'] = 'test_rel'
+        self.assertWarning(c, 'neg-aux')
+        c['aux1_stem1_pred'] = 'neg_rel'
+        self.assertNoWarnings(c, 'neg-aux')
 
     def test_coordination(self):
         # missing answers


### PR DESCRIPTION
#448 

Validating if neg aux is selected but no aux in lexicon with neg_rel predicate. 

<img width="908" alt="Screen Shot 2024-10-26 at 12 13 50 PM" src="https://github.com/user-attachments/assets/d8453e48-f345-4917-9814-3762dd55f218">
