### PR TITLE
error when case marked on aux subj but no case in language

### DIFF
--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -930,6 +930,10 @@ def validate_lexicon(ch, vr):
             if not stem.get('orth'):
                 mess = 'You must specify a spelling for each auxiliary you define.'
                 vr.err(stem.full_key + '_orth', mess)
+        
+        if aux.get('subj') in ['np-comp-case', 'np-aux-case'] and ch.get('case-marking') == 'none':
+            vr.err(aux.full_key + '_subj', 'You have specified that this language does not have case marking but indicated the subject ' + \
+                    'of this auxiliary has case.')
 
     # TODO: Copulas: TJT 2014-08-25
     # Copulas

--- a/gmcs/linglib/negation.py
+++ b/gmcs/linglib/negation.py
@@ -999,7 +999,7 @@ def validate(ch, vr):
             # ERB 2009-01-23 Commenting out the following because infl-neg is
             # now handled with customize_inflection.  We should eventually give
             # a warning if infl-neg is selected but no lexical rules actually
-            # use it.  I think it would make sense for that warning to go
+            # use it. I think it would make sense for that warning to go
             # on the negation page.
 
             # If affix is indicated, must select prefix/suffix and

--- a/tests/unit/validate_test.py
+++ b/tests/unit/validate_test.py
@@ -535,6 +535,14 @@ class TestValidate(unittest.TestCase):
         c['aux1_sem'] = ''
         c['aux1_stem1_pred'] = 'dummy'
         self.assertError(c, 'aux1_sem')
+        
+        c = ChoicesFile()
+        c['case-marking'] = 'none'
+        c['aux1_subj'] = 'np-comp-case'
+        self.assertError(c, 'aux1_subj')
+        
+        c['aux1_subj'] = 'np-aux-case'
+        self.assertError(c, 'aux1_subj')
 
         # Adpositions
         c = ChoicesFile()

--- a/web/matrixdef
+++ b/web/matrixdef
@@ -3034,6 +3034,7 @@ BeginIter aux{i} "an Auxiliary Type" 1
   Label "<br><br>"
 
   Radio subj "Aux {i} subject" "If this auxiliary type takes a VP or V complement, select the subject type:<br>" ""
+  . adp "Adpositional phrase" "" "adpositional phrase<br>"
   . np "Noun phrase" "" "noun phrase without case restrictions <br>"
   . np-comp-case "NP comp case" "" "noun phrase bearing the case the verbal complement assigns to its subject <br>"
   . np-aux-case "NP aux case" "" "noun phrase, receiving the following case from its auxiliary: "
@@ -3041,8 +3042,7 @@ BeginIter aux{i} "an Auxiliary Type" 1
   Select subj_case "Aux {i} subject-case" "" ""
   fillvalues p=case l=1
 
-  Radio subj "Aux {i} subject" "" ""
-  . adp "Adpositional phrase" "<br>" "adpositional phrase<br><br>"
+  Label "<br><br>"
 
   Label complabel "Complement Features:&nbsp; &nbsp; &nbsp; &nbsp; (Note: A
   value for the feature FORM is required.)<br>"


### PR DESCRIPTION
#464 

The bubble is hiding the selection, but this error will show if np-comp-case or np-aux-case are chosen. 

<img width="524" alt="Screen Shot 2024-10-29 at 4 50 23 PM" src="https://github.com/user-attachments/assets/20a1d4cb-92b5-41c9-b822-008a3c7010fd">

<img width="568" alt="Screen Shot 2024-10-29 at 4 50 40 PM" src="https://github.com/user-attachments/assets/dddc007f-9704-49a9-916c-c2435899de1d">
<img width="540" alt="Screen Shot 2024-10-29 at 4 50 28 PM" src="https://github.com/user-attachments/assets/a9769d59-10cf-48db-85cf-eb74b0e86149">
