### PR TITLE
612 duplicate head constraints

### DIFF
--- a/gmcs/linglib/case.py
+++ b/gmcs/linglib/case.py
@@ -342,7 +342,6 @@ def customize_verb_case(mylang, ch):
     # Which should get fixed...  - sfd
 
     # OZ: This currently also adds clausal types.
-
     for p in ch.patterns():
         rule_pattern = p[2]
         p = p[0].split(',')  # split off ',dirinv', if present
@@ -390,12 +389,14 @@ def customize_verb_case(mylang, ch):
                         mylang.add(t_type + ' := transitive-verb-lex.')
                     else:
                         mylang.add(t_type + ' := clausal-verb-lex.')
-                # constrain the head of the agent/subject
-                typedef = \
-                    t_type + ' := \
-          [ ARG-ST.FIRST.LOCAL.CAT.HEAD ' + a_head + ' ].'
-                mylang.add(typedef)
-
+    
+                # constrain the head of the agent/subject on parent transitive-verb-lex            
+                if t_type == 'transitive-verb-lex':
+                    typedef = \
+                        t_type + ' := \
+              [ ARG-ST.FIRST.LOCAL.CAT.HEAD ' + a_head + ' ].'
+                    mylang.add(typedef)
+          
                 # constrain the case of the agent/subject
                 if a_case:
                     typedef = \
@@ -411,12 +412,13 @@ def customize_verb_case(mylang, ch):
           [ SYNSEM.LOCAL.CAT.VAL.SUBJ < [ LOCAL.CAT.HEAD.CASE-MARKED + ] > ].'
                     mylang.add(typedef)
 
-                # constrain the head of the patient/object
-                if o_head:
-                    typedef = \
-                        t_type + ' := \
-          [ ARG-ST < [ ], [ LOCAL.CAT.HEAD ' + o_head + ' ] > ].'
-                    mylang.add(typedef)
+                # constrain the head of the patient/object on parent transitive-verb-lex
+                if t_type == 'transitive-verb-lex':
+                    if o_head:
+                        typedef = \
+                            t_type + ' := \
+              [ ARG-ST < [ ], [ LOCAL.CAT.HEAD ' + o_head + ' ] > ].'
+                        mylang.add(typedef)
 
                 # constrain the case of the patient/object
                 if o_case:
@@ -458,11 +460,12 @@ def customize_verb_case(mylang, ch):
                     else:
                         mylang.add(i_type + ' := clausal-verb-lex.')
 
-                # constrain the head of the subject
-                typedef = \
-                    i_type + ' := \
-          [ ARG-ST.FIRST.LOCAL.CAT.HEAD ' + s_head + ' ].'
-                mylang.add(typedef)
+                # constrain the head of the subject on parent intransitive-verb-lex
+                if i_type == 'intransitive-verb-lex':
+                    typedef = \
+                        i_type + ' := \
+              [ ARG-ST.FIRST.LOCAL.CAT.HEAD ' + s_head + ' ].'
+                    mylang.add(typedef)
 
                 # constrain the case of the subject
                 if s_case:

--- a/gmcs/linglib/lexicon.py
+++ b/gmcs/linglib/lexicon.py
@@ -408,10 +408,21 @@ def validate_lexicon(ch, vr):
             vr.warn(n.full_key + '_det', mess % message_map[det])
             
         q = n.get('inter')
-        wh_q1 = ch.get(MTRX_FRONT)
-        if q == 'on' and (not wh_q1):
-            vr.warn(n.full_key + '_inter', 'A noun defined as a question pronoun is unusable ' + \
-                    'without any constituent question selections.')
+        if q == 'on':
+            wh_q1 = ch.get(MTRX_FRONT)
+            if not wh_q1:
+                vr.warn(n.full_key + '_inter', 'A noun defined as a question pronoun is unusable ' + \
+                        'without any constituent question selections.')
+            for stem in s:
+                p = stem.get('pred')
+                ques_preds = ["who", "what", "when", "where"]
+                needsPredicateWarning = True
+                for qp in ques_preds:
+                    if re.search(qp, p) != None:
+                        needsPredicateWarning = False
+                if needsPredicateWarning:
+                    vr.warn(stem.full_key + '_pred', 'Suggested predicates for question ' + \
+                        'pronouns include _thing_n_rel, _person_n_rel, _place_n_rel, or similar.')
 
         for stem in s:
             orth = stem.get('orth')

--- a/tests/unit/validate_test.py
+++ b/tests/unit/validate_test.py
@@ -523,6 +523,14 @@ class TestValidate(unittest.TestCase):
         c['noun1_inter'] = 'on'
         self.assertWarnings(c, ['noun1_inter'])
         
+        # question pronoun, but not preferred predicate
+        c = ChoicesFile()
+        c['noun1_inter'] = 'on'
+        c['noun1_stem1_pred'] = '_test_n_rel'
+        self.assertWarning(c, 'noun1_stem1_pred')
+        c['noun1_stem1_pred'] = '_who_n_rel'
+        self.assertNoWarnings(c, ['noun1_stem1_pred'])
+        
         # Verbs
         c = ChoicesFile()
         c['verb1_dummy'] = 'dummy'

--- a/web/matrixdef
+++ b/web/matrixdef
@@ -1281,7 +1281,7 @@ on the morphology page.  Defining morphemes that specify [<span class=\"feat\">n
 
 Check neg-aux "Negation by auxiliary verb" "<p>" "Negative auxiliary verb:
 Checking this box creates a neg-aux type which contributes a neg_rel that
-outscopes it's complement's handle.  This lexical type will show up on the
+outscopes its complement's handle.  This lexical type will show up on the
 lexicon page where you'll need to further specify its syntax.</p>"
 
 Text neg-aux-index "index for neg aux" "<span style='display:none'>" "</span>" 1
@@ -2700,7 +2700,8 @@ BeginIter noun{i} "a Noun Type" 1 1
 
     Text orth "Noun {i} stem {j} spelling" "Spelling: " "" 30 "fill_pred('noun{i}_stem{j}', 'n')"
 
-    Text pred "Noun {i} stem {j} predicate" " Predicate: " "" 30
+    Text pred "Noun {i} stem {j} predicate" " Predicate: " "<br>Predicate suggestion for question pronouns: use _thing_n_rel, _person_n_rel, _place_n_rel or similar" 30
+    
 
   EndIter stem
 
@@ -4154,7 +4155,7 @@ Section ToolboxLexicon "Toolbox Lexicon" 0
 
 Label "<p> Imported Toolbox Lexical items are displayed here, if any of these are incorrect
 we recommend changing your import configurations and reimporting your files instead of
-directly correcing the entries.</p>"
+directly correcting the entries.</p>"
 
 Separator
 

--- a/web/matrixdef
+++ b/web/matrixdef
@@ -2700,7 +2700,7 @@ BeginIter noun{i} "a Noun Type" 1 1
 
     Text orth "Noun {i} stem {j} spelling" "Spelling: " "" 30 "fill_pred('noun{i}_stem{j}', 'n')"
 
-    Text pred "Noun {i} stem {j} predicate" " Predicate: " "<br>Predicate suggestion for question pronouns: use _thing_n_rel, _person_n_rel, _place_n_rel or similar" 30
+    Text pred "Noun {i} stem {j} predicate" " Predicate: " "" 30
     
 
   EndIter stem


### PR DESCRIPTION
#612 Only setting the HEAD constraints when the t_type/i_type is the parent transitive-verb-lex or intransitive-verb-lex. The following image can be compared with the image in the original ticket where HEAD +np was added to the subtypes as well. 

(Also I accidentally made this off of the other PR, so that should be approved first)
<img width="481" alt="Screen Shot 2024-11-11 at 2 07 08 PM" src="https://github.com/user-attachments/assets/1c2a3ed1-48c6-40e7-b895-b14b50560824">
