### PR TITLE
looking for supertype name for TAM features on aux to create correct trigger rule

### DIFF
--- a/gmcs/linglib/auxiliaries.py
+++ b/gmcs/linglib/auxiliaries.py
@@ -347,8 +347,7 @@ def get_users_type_name(aux):
     userstypename = name + '-aux-lex'
     return userstypename
 
-
-def add_auxiliaries_to_lexicon(userstypename, sem, aux, lexicon, trigger):
+def add_auxiliaries_to_lexicon(userstypename, sem, aux, lexicon, hierarchies, trigger):
     for stem in aux.get('stem', []):
         orth = orth_encode(stem.get('orth'))
         id = stem.get('name')
@@ -373,12 +372,14 @@ def add_auxiliaries_to_lexicon(userstypename, sem, aux, lexicon, trigger):
             tense = aspect = mood = evidential = ''
 
             for feat in aux.get('feat', []):
-                if feat.get('name') == 'tense':
-                    tense = feat.get('value')
-                if feat.get('name') == 'aspect':
-                    aspect = feat.get('value')
-                if feat.get('name') == 'mood':
-                    mood = feat.get('value')
+                n = feat.get('name', '')
+                v = feat.get('value', '').split(', ')
+                if n == 'tense' and n in hierarchies:
+                    tense = hierarchies[n].get_type_covering(v)
+                if n == 'aspect' and n in hierarchies:
+                    aspect = hierarchies['aspect'].get_type_covering(v)
+                if n == 'mood' and n in hierarchies:
+                    mood = hierarchies['mood'].get_type_covering(v)
                 if feat.get('name') == 'evidential':
                     evidential = feat.get('value')
 
@@ -424,4 +425,4 @@ def customize_auxiliaries(mylang, ch, lexicon, trigger, hierarchies):
 
         define_arg_str_and_valency(aux, auxcomp, ch, mylang, negaux)
         create_semantics(sem, aux, auxcomp, mylang, ch, hierarchies, negaux)
-        add_auxiliaries_to_lexicon(userstypename, sem, aux, lexicon, trigger)
+        add_auxiliaries_to_lexicon(userstypename, sem, aux, lexicon, hierarchies, trigger)

--- a/matrix-core/matrix.tdl
+++ b/matrix-core/matrix.tdl
@@ -1589,7 +1589,8 @@ headed-phrase := phrase &
 		   CONT.HOOK.ICONS-KEY #icons,
 		   AGR #agr,
 		   COORD -,
-		   COORD-REL #crel ] ].
+		   COORD-REL #crel ],
+    NON-HEAD-DTR sign & [ SYNSEM.LOCAL.COORD - ] ].
 
 non-headed-phrase := phrase.
 
@@ -1712,8 +1713,7 @@ binary-phrase := basic-binary-phrase &
     ARGS < [ INFLECTED infl-satisfied ],
            [ INFLECTED infl-satisfied ] > ].
 
-basic-binary-headed-phrase := headed-phrase & basic-binary-phrase &
-  [ NON-HEAD-DTR sign & [ SYNSEM.LOCAL.COORD - ] ].
+basic-binary-headed-phrase := headed-phrase & basic-binary-phrase.
 
 binary-headed-phrase := basic-binary-headed-phrase & binary-phrase.
 
@@ -1778,8 +1778,7 @@ ternary-phrase := basic-ternary-phrase &
              SYNSEM.LOCAL.COORD - ] > ].
 
 
-ternary-headed-phrase := headed-phrase & ternary-phrase &
-  [ NON-HEAD-DTR sign & [ SYNSEM.LOCAL.COORD - ] ].
+ternary-headed-phrase := headed-phrase & ternary-phrase.
 
 ; ERB (2007-02-12) Hypothesizing for now that these will never be fulfilling
 ; valence requirements of the head, so just copy that up.


### PR DESCRIPTION
#599 
Trigger rule now looks like:
<img width="383" alt="Screen Shot 2024-11-15 at 6 31 45 PM" src="https://github.com/user-attachments/assets/a4ef5ab1-1ade-4030-b9a9-042aa72f103c">

Second portion of this is to fix something that came up from https://github.com/delph-in/matrix/pull/765
Although all the regression tests passed with that PR ^, I just noticed when trying to load a grammar into the LKB that there was an error loading because NON-HEAD-DTR was defined in two places (ternary-headed-phrase and basic-binary-headed-phrase) so I looked for where I could put it on a supertype instead of each. I'm not sure WHY it can't be defined twice, but once I changed it to this, all tests still pass and the LKB loads the grammar and parses. I see that there are other things that also inherit from headed-phrase so I'm not sure if it is okay to put there. Please let me know if this is incorrect and if there is a different solution. 
