### PR TITLE
including instructions for installing ace the proper way

### DIFF
--- a/install_ace.sh
+++ b/install_ace.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Following instructions from: https://github.com/delph-in/docs/wiki/AceInstall
+# Choose ready-to-run ACE binary download from https://sweaglesw.org/linguistics/ace/
+TAR_URL="https://sweaglesw.org/linguistics/ace/download/ace-0.9.34-x86-64.tar.gz"
+sudo apt install curl
+curl -L $TAR_URL -o /tmp/file.tar.gz
+mkdir -p /tmp/extracted
+tar -xzvf /tmp/file.tar.gz -C /tmp/extracted
+chmod +x /tmp/extracted/ace-0.9.34/ace
+# destination path depends on where your bin is
+sudo mv /tmp/extracted/ace-0.9.34/ace /usr/local/bin/ace
+
+exit_status=$?
+
+if [ $exit_status -ne 0 ]; then
+  echo "Error occurred: Command failed with exit status $exit_status"
+  exit 1
+else
+  echo "Successfully installed ace"
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pydelphin==1.4.0
+
+# Run ./install_ace.sh

--- a/web/matrixdef
+++ b/web/matrixdef
@@ -1384,7 +1384,7 @@ Radio comp-neg-head-infl-comp-neg "neg selected by" "Is neg selected by" "<br />
 . aux "aux" "" "a (sub-)class of aux-verbs" "neg_comp()"
 . v   "v"   "" "any (finite) verb" "neg_comp()"
 
-Radio comp-neg-order-infl-head "neg ordered" "How is neg ordered with resepct
+Radio comp-neg-order-infl-head "neg ordered" "How is neg ordered with respect
 to other COMPS?" "<br />(NB: After other complements order is only available
 for non-argument composing auxiliaries.)<br />"
 . before "before" "" "before "


### PR DESCRIPTION
Ace does not come installed with pydelphin and this was not mentioned anywhere, so I've included a script that follows the linked instructions from AceInstall making the process simpler. 