### PR TITLE
adding namespace collision logic for sentential negation page with auxes in lexicon

### DIFF
--- a/gmcs/linglib/lexical_items.py
+++ b/gmcs/linglib/lexical_items.py
@@ -16,6 +16,8 @@ from gmcs.linglib.nominalized_clauses import needs_anc_wo_feat
 from gmcs.linglib.parameters import determine_vcluster
 from gmcs.linglib.lexbase import ALL_LEX_TYPES, LEXICAL_SUPERTYPES
 from gmcs.linglib.lexicon import get_all_supertypes
+from gmcs.linglib.negation import get_neg_stemids
+from gmcs.linglib.negation import add_neg_name
 from gmcs.linglib.clausalmods import get_subord_stemids
 from gmcs.linglib.clausalmods import add_subord_name
 from gmcs.feature_type_use import USED_TYPES
@@ -109,10 +111,11 @@ def insert_ids(ch):
                     stemids[id] += 1
                 else:
                     stemids[id] = 1
-    # KPH Subordinators are added outside the lexicon,
+    # KPH Subordinators and negators are added outside the lexicon,
     # but should still be checked for possible name-space collisions
     # this should be a temporary/hacky fix- a bug has been filed
     stemids = get_subord_stemids(ch, stemids)
+    stemids = get_neg_stemids(ch, stemids)
 
     # Now that stemids has the full count, go through and add
     # to the choices file object.
@@ -143,7 +146,7 @@ def insert_ids(ch):
                         '_' + str(stemidcounters[orth])
     # KPH Do the same for subordinators and complementizers
     add_subord_name(ch, stemids, stemidcounters)
-
+    add_neg_name(ch, stemids, stemidcounters)
 
 ##########################################################
 

--- a/gmcs/linglib/negation.py
+++ b/gmcs/linglib/negation.py
@@ -1,8 +1,6 @@
 from gmcs.utils import TDLencode
 from gmcs.utils import orth_encode
 
-######################################################################
-
 def customize_sentential_negation(mylang, ch, lexicon, rules, lrules, hierarchies):
     """
     Create the type definitions associated with the user's choices
@@ -1109,3 +1107,63 @@ def validate(ch, vr):
 #     if (not ch.get('multi-neg')):
 #       mess = 'If you have selected both affix and adverb realizations of sentential negation, you must specify how they interact.'
 #       vr.err('multi-neg', mess)
+
+def get_neg_stemids(ch, stemids):
+    """
+    A function called by insert_ids() in lexical_items.py to check for 
+    name-space-collisions.
+    """
+    # The neg aux have already been added in insert_ids() so now just compare 
+    # with those possibly added negators from negation page.
+    # The logic will only allow one construction to be implemented.
+    # With simple construction, two adverbs are possible but 
+    # are handled as one entry if the ORTH value is the same. The only naming conflict 
+    # possible is between a negative aux and adverb. However, in the future when multiple 
+    # constructions are supported, this will allow more than one negator to be handled.
+    # TODO: For now, there is a bug where choices from one construction remain
+    # after switching to another so it is possible that i.e. a bipartite orth 
+    # and simple orth exist and need to be handled, even though currently only one 
+    # will be included in the grammar. This means that the orth ids might not 
+    # increment perfectly, but they will not conflict. 
+    other_neg_orth = ['neg-adv-orth', 'comp-neg-orth', 'neg-mod-orth', 'neg-comp-orth', \
+                        'comp-neg1-orth', 'comp-neg2-orth', 'neg1-mod-orth', 'neg2-mod-orth']
+    for ono in other_neg_orth:
+        if ch.get(ono):
+            orth = ch.get(ono)
+            if orth in list(stemids.keys()):
+                stemids[orth] += 1
+            else:
+                stemids[orth] = 1
+    return stemids
+
+def add_neg_name(ch, stemids, stemidcounters):
+    """
+    A function called by insert_ids() in lexical_items.py to
+    create a "name" for each negator in choices, preventing
+    name-space-collisions.
+    """
+    # The logic will only allow one construction to be implemented.
+    # With simple construction, two adverbs are possible but 
+    # are handled as one entry if the ORTH value is the same. The only naming conflict 
+    # possible is between a negative aux and adverb. However, in the future when multiple 
+    # constructions are supported, this will allow more than one negator to be handled.
+    # TODO: For now, there is a bug where choices from one construction remain
+    # after switching to another so it is possible that i.e. a bipartite orth 
+    # and simple orth exist and need to be handled, even though currently only one 
+    # will be included in the grammar. This means that the orth ids might not 
+    # increment perfectly, but they will not conflict. 
+    other_neg_orth = ['neg-adv-orth', 'comp-neg-orth', 'neg-mod-orth', 'neg-comp-orth', \
+                        'comp-neg1-orth', 'comp-neg2-orth', 'neg1-mod-orth', 'neg2-mod-orth']
+    for ono in other_neg_orth:
+        if ch.get(ono):
+            orth = ch.get(ono)
+            if stemids[orth] == 1:
+                ch[ono + '_name'] = orth
+            elif orth not in stemidcounters:
+                stemidcounters[orth] = 1
+                ch[ono + '_name'] = orth + '_1'
+            else:
+                stemidcounters[orth] += 1
+                ch[ono + '_name'] = orth + \
+                    '_' + str(stemidcounters[orth])
+


### PR DESCRIPTION
This is to fix #597 
I updated the choices file that was included in the issue since it did not pass more recent validation. Updated copy is attached. 
[buggy-neg-final.txt](https://github.com/user-attachments/files/17891593/buggy-neg-final.txt)
This will add numeric suffixes to the aux since this goes through the same namespace collision logic as nouns and verbs. Adverbs on the other hand will not have such collisions so remain as the originally named entry. The stem is the same but now there is a separate lexical entry for the adverb and the auxiliary instead of one entry thatt inherits from both rules. 
<img width="331" alt="Screen Shot 2024-11-23 at 9 53 36 PM" src="https://github.com/user-attachments/assets/cb650536-954a-4434-8ed2-e9a05c91269f">
