### PR TITLE
Emilyldev

### DIFF
--- a/gmcs/linglib/morphotactics.py
+++ b/gmcs/linglib/morphotactics.py
@@ -1313,6 +1313,10 @@ def lrt_validation(lrt, vr, index_feats, choices, incorp=False, inputs=set(), sw
                'Any given Lexical Rule Type should contain either inflecting Lexical Rule Instances ' +
                'or non-inflecting Lexical Rule Instances.')
     orths = set()
+    # EEL 2025-1-15 validating that lrts must specify if they are inflecting or not
+    if len(lrt.get('lri', [])) == 0:
+        vr.err(lrt.full_key + '_lri',
+                "You must specify whether each instance is inflecting or non-inflecting.")
     for lri in lrt.get('lri', []):
         orth = lri.get('orth', '')
         if lri['inflecting'] == 'yes' and orth == '':

--- a/tests/unit/validate_test.py
+++ b/tests/unit/validate_test.py
@@ -617,5 +617,16 @@ class TestValidate(unittest.TestCase):
                               'obj-mark-drop', 'obj-mark-no-drop',
                               'context1_feat1_head'])
 
+    def test_lrt(self):
+        c = ChoicesFile()
+        lt = 'verb-pc1_lrt'
+        feature_name = 'feat1'
+        for head in ['subj', 'obj', 'noun']:
+            c[lt + '1_feat1_name'] = feature_name
+            c['feature1_name'] = feature_name
+            c['feature1_cat'] = 'verb'
+            c[lt + '1_feat1_head'] = head
+        self.assertError(c, lt + '1_lri')
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added validation in morphotactics.py to ensure that users indicate if lrts are inflecting or not. I also created a unit test to assert that the correct error message appears for this type of error. 